### PR TITLE
Add additional check to avoid flaky tests.

### DIFF
--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
@@ -65,9 +65,9 @@ public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
         final SearchDsl<ProductProjection> search = ProductProjectionSearch.of(STAGED).withSort(sortByCreatedAt).plusFacet(facet);
         execute(search, res -> {
             final List<String> ids = SphereTestUtils.toIds(res.getResults());
-            boolean productsExist = ids.contains(product1.getId()) && ids.contains(product2.getId()) && ids.contains(product3.getId())
-                    && ids.contains(evilProduct1.getId()) && ids.contains(evilProduct2.getId());
-            boolean facetsExist = res.getTermFacetResult(facet).map(term -> term.getMissing() > 1 && term.getTotal() > 1).orElse(false);
+            final boolean productsExist = ids.contains(product1.getId()) && ids.contains(product2.getId())
+                    && ids.contains(product3.getId()) && ids.contains(evilProduct1.getId()) && ids.contains(evilProduct2.getId());
+            final boolean facetsExist = res.getTermFacetResult(facet).map(term -> term.getMissing() > 1 && term.getTotal() > 1).orElse(false);
             return productsExist && facetsExist;
         });
         try {

--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
@@ -1,7 +1,6 @@
 package io.sphere.sdk.products;
 
 import io.sphere.sdk.attributes.*;
-import io.sphere.sdk.client.SphereRequest;
 import io.sphere.sdk.models.LocalizedStrings;
 import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.commands.ProductDeleteCommand;
@@ -15,10 +14,13 @@ import io.sphere.sdk.producttypes.queries.ProductTypeQuery;
 import io.sphere.sdk.queries.QueryDsl;
 import io.sphere.sdk.search.*;
 import io.sphere.sdk.test.IntegrationTest;
+import io.sphere.sdk.test.RetryIntegrationTest;
 import io.sphere.sdk.test.SphereTestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
@@ -36,7 +38,6 @@ import static java.lang.Math.min;
 import static java.math.BigDecimal.*;
 import static java.util.Arrays.asList;
 import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.Fail.fail;
 
 public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
     private static final String EVIL_CHARACTER_WORD = "öóßàç";
@@ -55,79 +56,14 @@ public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
     public static final String ATTR_NAME_SIZE = ("Size" + TEST_CLASS_NAME).substring(0, min(20, TEST_CLASS_NAME.length()));
     public static final String ATTR_NAME_EVIL = ("Evil" + TEST_CLASS_NAME).substring(0, min(20, TEST_CLASS_NAME.length()));
 
+    @Rule
+    public RetryIntegrationTest retry = new RetryIntegrationTest(10, LoggerFactory.getLogger(this.getClass()));
+
     @BeforeClass
     public static void setupProducts() {
         removeProducts();
         setupTestProducts();
         setupEvilTestProducts();
-        final SearchSort<ProductProjection> sortByCreatedAt = ProductProjectionSearch.model().createdAt().sort(SimpleSearchSortDirection.DESC);
-        final TermFacetExpression<ProductProjection, String> facet = ProductProjectionSearch.model().allVariants().attribute().ofText(ATTR_NAME_COLOR).facetOf().all();
-        final SearchDsl<ProductProjection> search = ProductProjectionSearch.of(STAGED).withSort(sortByCreatedAt).plusFacet(facet);
-        execute(search, res -> {
-            final List<String> ids = SphereTestUtils.toIds(res.getResults());
-            final boolean productsExist = ids.contains(product1.getId()) && ids.contains(product2.getId())
-                    && ids.contains(product3.getId()) && ids.contains(evilProduct1.getId()) && ids.contains(evilProduct2.getId());
-            final boolean facetsExist = res.getTermFacetResult(facet).map(term -> term.getMissing() > 1 && term.getTotal() > 1).orElse(false);
-            /**
-             * Having the products in ES is not guarantee enough that ES will be able to include them in its facets calculations (and the same
-             * applies to sort, filters, search related processes). Therefore, now it is additionally checking that the facets are being
-             * calculated before deciding the tests are ready to be executed. Moreover the tests wait some more before starting, as it is
-             * commanded in the next Thread.sleep.
-             */
-            return productsExist && facetsExist;
-        });
-        try {
-            Thread.sleep(1000); // Wait for elasticsearch synchronization (increase if tests are returning wrong values)
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void setupTestProducts() {
-        final AttributeDefinition colorAttrDef = AttributeDefinitionBuilder
-                .of(ATTR_NAME_COLOR, LocalizedStrings.ofEnglishLocale(ATTR_NAME_COLOR), TextType.of()).isSearchable(true).build();
-        final AttributeDefinition sizeAttrDef = AttributeDefinitionBuilder
-                .of(ATTR_NAME_SIZE, LocalizedStrings.ofEnglishLocale(ATTR_NAME_SIZE), NumberType.of()).isSearchable(true).build();
-        final ProductTypeDraft productTypeDraft = ProductTypeDraft.of(TEST_CLASS_NAME, "", asList(colorAttrDef, sizeAttrDef));
-        final ProductTypeCreateCommand productTypeCreateCommand = ProductTypeCreateCommand.of(productTypeDraft);
-        productType = execute(productTypeCreateCommand);
-        product1 = createTestProduct(productType, "Schuh", "shoe", "blue", 38, 46);
-        product2 = createTestProduct(productType, "Hemd", "shirt", "red", 36, 44);
-        product3 = createTestProduct(productType, "Kleider", "dress", "blue", 40, 42);
-
-    }
-
-    private static void setupEvilTestProducts() {
-        final AttributeDefinition evilAttrDef = AttributeDefinitionBuilder
-                .of(ATTR_NAME_EVIL, LocalizedStrings.ofEnglishLocale(ATTR_NAME_EVIL), TextType.of()).isSearchable(true).build();
-        final ProductTypeDraft evilProductTypeDraft = ProductTypeDraft.of("Evil" + TEST_CLASS_NAME, "", asList(evilAttrDef));
-        final ProductTypeCreateCommand evilProductTypeCreateCommand = ProductTypeCreateCommand.of(evilProductTypeDraft);
-        evilProductType = execute(evilProductTypeCreateCommand);
-        evilProduct1 = createEvilTestProduct(evilProductType, EVIL_CHARACTER_WORD, "foo");
-        evilProduct2 = createEvilTestProduct(evilProductType, "bar", EVIL_CHARACTER_WORD);
-
-    }
-
-    private static Product createTestProduct(final ProductType productType, final String germanName, final String englishName,
-                                             final String color, final int size1, final int size2) {
-        final LocalizedStrings name = LocalizedStrings.of(GERMAN, germanName, ENGLISH, englishName);
-        final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of()
-                .attributes(Attribute.of(ATTR_NAME_SIZE, size1), Attribute.of(ATTR_NAME_COLOR, color))
-                .price(Price.of(new BigDecimal("23.45"), EUR)).build();
-        final ProductVariantDraft variant = ProductVariantDraftBuilder.of()
-                .attributes(Attribute.of(ATTR_NAME_SIZE, size2))
-                .price(Price.of(new BigDecimal("27.45"), EUR)).build();
-        final ProductDraft productDraft = ProductDraftBuilder.of(productType, name, name.slugified(), masterVariant)
-                .variants(asList(variant)).build();
-        return execute(ProductCreateCommand.of(productDraft));
-    }
-
-    private static Product createEvilTestProduct(final ProductType productType, final String germanName, final String evilValue) {
-        final LocalizedStrings name = LocalizedStrings.of(GERMAN, germanName);
-        final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of()
-                .attributes(Attribute.of(ATTR_NAME_EVIL, evilValue)).build();
-        final ProductDraft productDraft = ProductDraftBuilder.of(productType, name, name.slugified(), masterVariant).build();
-        return execute(ProductCreateCommand.of(productDraft));
     }
 
     @AfterClass
@@ -141,19 +77,6 @@ public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
         evilProduct2 = null;
         productType = null;
         evilProductType = null;
-    }
-
-    private static void removeProductTypeAndItsProducts(final ProductType productType) {
-        if (productType != null) {
-            final QueryDsl<ProductType> request = ProductTypeQuery.of().byName(productType.getName());
-            List<ProductType> productTypes = execute(request).getResults();
-            if (!productTypes.isEmpty()) {
-                final List<ProductProjection> products = execute(ProductProjectionQuery.of(STAGED)
-                        .withPredicate(ProductProjectionQuery.model().productType().isAnyOf(productTypes))).getResults();
-                products.forEach(p -> execute(ProductDeleteCommand.of(p.toProductVersioned())));
-                productTypes.forEach(p -> execute(ProductTypeDeleteCommand.of(p)));
-            }
-        }
     }
 
     @Test
@@ -382,41 +305,79 @@ public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
         assertThat(result.getTotal()).isEqualTo(1);
     }
 
-    private List<String> resultsToIds(final PagedSearchResult<ProductProjection> result) {
+    private static List<String> resultsToIds(final PagedSearchResult<ProductProjection> result) {
         return SphereTestUtils.toIds(result.getResults());
     }
 
-    protected static PagedSearchResult<ProductProjection> executeSearch(final SearchDsl<ProductProjection> searchDsl) {
+    private static PagedSearchResult<ProductProjection> executeSearch(final SearchDsl<ProductProjection> searchDsl) {
         final FilterExpression<ProductProjection> onlyCreatedProducts = FilterExpression.of(
                 String.format("id:\"%s\",\"%s\",\"%s\"", product1.getId(), product2.getId(), product3.getId()));
         return execute(searchDsl.plusFilterQuery(onlyCreatedProducts));
     }
 
-    protected static PagedSearchResult<ProductProjection> executeEvilSearch(final SearchDsl<ProductProjection> searchDsl) {
+    private static PagedSearchResult<ProductProjection> executeEvilSearch(final SearchDsl<ProductProjection> searchDsl) {
         final FilterExpression<ProductProjection> onlyCreatedProducts = FilterExpression.of(
                 String.format("id:\"%s\",\"%s\"", evilProduct1.getId(), evilProduct2.getId()));
         return execute(searchDsl.plusFilterQuery(onlyCreatedProducts));
     }
 
-    protected static <T> T execute(final SphereRequest<T> clientRequest, final Predicate<T> isOk) {
-        return execute(clientRequest, 9, isOk);
+    private static void setupTestProducts() {
+        final AttributeDefinition colorAttrDef = AttributeDefinitionBuilder
+                .of(ATTR_NAME_COLOR, LocalizedStrings.ofEnglishLocale(ATTR_NAME_COLOR), TextType.of()).isSearchable(true).build();
+        final AttributeDefinition sizeAttrDef = AttributeDefinitionBuilder
+                .of(ATTR_NAME_SIZE, LocalizedStrings.ofEnglishLocale(ATTR_NAME_SIZE), NumberType.of()).isSearchable(true).build();
+        final ProductTypeDraft productTypeDraft = ProductTypeDraft.of(TEST_CLASS_NAME, "", asList(colorAttrDef, sizeAttrDef));
+        final ProductTypeCreateCommand productTypeCreateCommand = ProductTypeCreateCommand.of(productTypeDraft);
+        productType = execute(productTypeCreateCommand);
+        product1 = createTestProduct(productType, "Schuh", "shoe", "blue", 38, 46);
+        product2 = createTestProduct(productType, "Hemd", "shirt", "red", 36, 44);
+        product3 = createTestProduct(productType, "Kleider", "dress", "blue", 40, 42);
+
     }
 
-    protected static <T> T execute(final SphereRequest<T> clientRequest, final int attemptsLeft, final Predicate<T> isOk) {
-        if (attemptsLeft < 1) {
-            fail("Could not satisfy the request.");
-        }
-        T result = execute(clientRequest);
-        if (isOk.test(result)) {
-            return result;
-        } else {
-            LoggerFactory.getLogger(ProductProjectionSearchIntegrationTest.class).info("attempts left " + (attemptsLeft - 1));
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+    private static void setupEvilTestProducts() {
+        final AttributeDefinition evilAttrDef = AttributeDefinitionBuilder
+                .of(ATTR_NAME_EVIL, LocalizedStrings.ofEnglishLocale(ATTR_NAME_EVIL), TextType.of()).isSearchable(true).build();
+        final ProductTypeDraft evilProductTypeDraft = ProductTypeDraft.of("Evil" + TEST_CLASS_NAME, "", asList(evilAttrDef));
+        final ProductTypeCreateCommand evilProductTypeCreateCommand = ProductTypeCreateCommand.of(evilProductTypeDraft);
+        evilProductType = execute(evilProductTypeCreateCommand);
+        evilProduct1 = createEvilTestProduct(evilProductType, EVIL_CHARACTER_WORD, "foo");
+        evilProduct2 = createEvilTestProduct(evilProductType, "bar", EVIL_CHARACTER_WORD);
+
+    }
+
+    private static Product createTestProduct(final ProductType productType, final String germanName, final String englishName,
+                                             final String color, final int size1, final int size2) {
+        final LocalizedStrings name = LocalizedStrings.of(GERMAN, germanName, ENGLISH, englishName);
+        final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of()
+                .attributes(Attribute.of(ATTR_NAME_SIZE, size1), Attribute.of(ATTR_NAME_COLOR, color))
+                .price(Price.of(new BigDecimal("23.45"), EUR)).build();
+        final ProductVariantDraft variant = ProductVariantDraftBuilder.of()
+                .attributes(Attribute.of(ATTR_NAME_SIZE, size2))
+                .price(Price.of(new BigDecimal("27.45"), EUR)).build();
+        final ProductDraft productDraft = ProductDraftBuilder.of(productType, name, name.slugified(), masterVariant)
+                .variants(asList(variant)).build();
+        return execute(ProductCreateCommand.of(productDraft));
+    }
+
+    private static Product createEvilTestProduct(final ProductType productType, final String germanName, final String evilValue) {
+        final LocalizedStrings name = LocalizedStrings.of(GERMAN, germanName);
+        final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of()
+                .attributes(Attribute.of(ATTR_NAME_EVIL, evilValue)).build();
+        final ProductDraft productDraft = ProductDraftBuilder.of(productType, name, name.slugified(), masterVariant).build();
+        return execute(ProductCreateCommand.of(productDraft));
+    }
+
+    private static void removeProductTypeAndItsProducts(final ProductType productType) {
+        if (productType != null) {
+            final QueryDsl<ProductType> request = ProductTypeQuery.of().byName(productType.getName());
+            List<ProductType> productTypes = execute(request).getResults();
+            if (!productTypes.isEmpty()) {
+                final List<ProductProjection> products = execute(ProductProjectionQuery.of(STAGED)
+                        .withPredicate(ProductProjectionQuery.model().productType().isAnyOf(productTypes))).getResults();
+                products.forEach(p -> execute(ProductDeleteCommand.of(p.toProductVersioned())));
+                productTypes.forEach(p -> execute(ProductTypeDeleteCommand.of(p)));
             }
-            return execute(clientRequest, attemptsLeft - 1, isOk);
         }
     }
 }

--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
@@ -68,6 +68,12 @@ public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
             final boolean productsExist = ids.contains(product1.getId()) && ids.contains(product2.getId())
                     && ids.contains(product3.getId()) && ids.contains(evilProduct1.getId()) && ids.contains(evilProduct2.getId());
             final boolean facetsExist = res.getTermFacetResult(facet).map(term -> term.getMissing() > 1 && term.getTotal() > 1).orElse(false);
+            /**
+             * Having the products in ES is not guarantee enough that ES will be able to include them in its facets calculations (and the same
+             * applies to sort, filters, search related processes). Therefore, now it is additionally checking that the facets are being
+             * calculated before deciding the tests are ready to be executed. Moreover the tests wait some more before starting, as it is
+             * commanded in the next Thread.sleep.
+             */
             return productsExist && facetsExist;
         });
         try {

--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
@@ -71,7 +71,7 @@ public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
             return productsExist && facetsExist;
         });
         try {
-            Thread.sleep(500); // Wait for elasticsearch synchronization (increase if tests are returning wrong values)
+            Thread.sleep(1000); // Wait for elasticsearch synchronization (increase if tests are returning wrong values)
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
@@ -20,7 +20,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;

--- a/sphere-test-lib/src/main/java/io/sphere/sdk/test/RetryIntegrationTest.java
+++ b/sphere-test-lib/src/main/java/io/sphere/sdk/test/RetryIntegrationTest.java
@@ -1,0 +1,37 @@
+package io.sphere.sdk.test;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+
+public class RetryIntegrationTest implements TestRule {
+    private final int maxAttempts;
+    private final Logger logger;
+
+    public RetryIntegrationTest(final int maxAttempts, final Logger logger) {
+        this.maxAttempts = maxAttempts;
+        this.logger = logger;
+    }
+
+    @Override
+    public Statement apply(final Statement test, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable lastThrowable = null;
+                for (int attempt = 0; attempt < maxAttempts; attempt++) {
+                    try {
+                        Thread.sleep(100);
+                        test.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        logger.info(String.format("%s failed %d/%d", description.getMethodName(), attempt + 1, maxAttempts));
+                        lastThrowable = t;
+                    }
+                }
+                throw lastThrowable;
+            }
+        };
+    }
+}

--- a/sphere-test-lib/src/main/java/io/sphere/sdk/test/RetryIntegrationTest.java
+++ b/sphere-test-lib/src/main/java/io/sphere/sdk/test/RetryIntegrationTest.java
@@ -22,9 +22,11 @@ public class RetryIntegrationTest implements TestRule {
                 Throwable lastThrowable = null;
                 for (int attempt = 0; attempt < maxAttempts; attempt++) {
                     try {
-                        Thread.sleep(100);
+                        Thread.sleep(200);
                         test.evaluate();
                         return;
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
                     } catch (Throwable t) {
                         logger.info(String.format("%s failed %d/%d", description.getMethodName(), attempt + 1, maxAttempts));
                         lastThrowable = t;


### PR DESCRIPTION
So the problem is that there is a delay from the moment the products are in ES and the moment when they can be used for some facets, sort and filter requests. I solved it with an additional check that seems to work very well in localhost. Anyway, I've increased the delay just to make sure the check is not skipping some case.

Please @schleichardt review.

Fixes https://github.com/sphereio/sphere-jvm-sdk/issues/382