### PR TITLE
Improve error messages and documentation for CustomerSignInCommand. #397

### DIFF
--- a/sphere-java-client-ning-1_8/src/main/java/io/sphere/sdk/client/SphereClientFactory.java
+++ b/sphere-java-client-ning-1_8/src/main/java/io/sphere/sdk/client/SphereClientFactory.java
@@ -83,7 +83,7 @@ public class SphereClientFactory extends Base {
                 final HttpRequestIntent httpRequest = sphereRequest.httpRequestIntent();
                 final HttpResponse httpResponse = function.apply(httpRequest);
                 try {
-                    final T t = SphereClientImpl.parse(httpResponse, sphereRequest, objectMapper, SphereApiConfig.of("fake-project-key-for-testing", "https://createHttpTestDouble.tld"));
+                    final T t = SphereClientImpl.parse(sphereRequest, objectMapper, SphereApiConfig.of("fake-project-key-for-testing", "https://createHttpTestDouble.tld"), httpResponse);
                     return CompletableFutureUtils.successful(t);
                 } catch (final Exception e) {
                     return CompletableFutureUtils.failed(e);

--- a/sphere-java-client-ning-1_9/src/main/java/io/sphere/sdk/client/SphereClientFactory.java
+++ b/sphere-java-client-ning-1_9/src/main/java/io/sphere/sdk/client/SphereClientFactory.java
@@ -83,7 +83,7 @@ public class SphereClientFactory extends Base {
                 final HttpRequestIntent httpRequest = sphereRequest.httpRequestIntent();
                 final HttpResponse httpResponse = function.apply(httpRequest);
                 try {
-                    final T t = SphereClientImpl.parse(httpResponse, sphereRequest, objectMapper, SphereApiConfig.of("fake-project-key-for-testing", "https://createHttpTestDouble.tld"));
+                    final T t = SphereClientImpl.parse(sphereRequest, objectMapper, SphereApiConfig.of("fake-project-key-for-testing", "https://createHttpTestDouble.tld"), httpResponse);
                     return CompletableFutureUtils.successful(t);
                 } catch (final Exception e) {
                     return CompletableFutureUtils.failed(e);

--- a/sphere-models/src/it/java/io/sphere/sdk/customers/commands/CustomerSignInCommandTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/customers/commands/CustomerSignInCommandTest.java
@@ -1,5 +1,7 @@
 package io.sphere.sdk.customers.commands;
 
+import io.sphere.sdk.client.ErrorResponseException;
+import io.sphere.sdk.customers.CustomerInvalidCredentials;
 import io.sphere.sdk.customers.CustomerSignInResult;
 import io.sphere.sdk.test.IntegrationTest;
 import org.junit.Test;
@@ -8,7 +10,7 @@ import java.util.Optional;
 
 import static io.sphere.sdk.customers.CustomerFixtures.PASSWORD;
 import static io.sphere.sdk.customers.CustomerFixtures.withCustomer;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class CustomerSignInCommandTest extends IntegrationTest {
     @Test
@@ -16,6 +18,15 @@ public class CustomerSignInCommandTest extends IntegrationTest {
         withCustomer(client(), customer -> {
             final CustomerSignInResult result = execute(CustomerSignInCommand.of(customer.getEmail(), PASSWORD, Optional.empty()));
             assertThat(result.getCustomer()).isEqualTo(customer);
+        });
+    }
+
+    @Test
+    public void executionWithInvalidEmail() throws Exception {
+        withCustomer(client(), customer -> {
+            assertThatThrownBy(() -> execute(CustomerSignInCommand.of("notpresent@null.sphere.io", PASSWORD, Optional.empty())))
+                    .isInstanceOf(ErrorResponseException.class)
+                    .matches(e -> ((ErrorResponseException) e).hasErrorCode(CustomerInvalidCredentials.CODE));
         });
     }
 }


### PR DESCRIPTION
@lauraluiz please review

The CustomerSignInCommand throwed in the error case an exception without the request and the response information.
I refactored a little bit the client impl to make the stack trace nicer.