### PR TITLE
Update dependencies. close #612

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,18 @@ see https://github.com/sphereio/sphere-jvm-sdk-experimental-java-add-ons
 
 ## Short-term roadmap
 * https://github.com/sphereio/sphere-jvm-sdk/milestones
+
+## Stability
+
+1. Experimental features in the API are also experimental features of the SDK.
+    * this includes for example
+        * cart discounts
+        * custom fields
+        * discount codes
+        * types endpoint/custom fields
+    * the stable and instable features can be mixed
+        * a cart contains the reference to its discounts
+1. The dependencies will only be updated in the next major version to improve stability. Of course, if bugs in libraries *occur*, we may need to update.
+1. JVM SDK test dependencies and build tools can be updated because they don't affect the production code.
+1. The JVM SDK has an abstract HTTP client layer so old or new http client versions can be used.
+1. class names containing the word "Experimental" can change at any time.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ see https://github.com/sphereio/sphere-jvm-sdk-experimental-java-add-ons
         * custom fields
         * discount codes
         * types endpoint/custom fields
-    * the stable and instable features can be mixed
+    * the stable and unstable features can be mixed
         * a cart contains the reference to its discounts
 1. The dependencies will only be updated in the next major version to improve stability. Of course, if bugs in libraries *occur*, we may need to update.
 1. JVM SDK test dependencies and build tools can be updated because they don't affect the production code.

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -6,7 +6,7 @@ object Libs extends json with http with other with test {
 }
 
 trait json {
-  private val jacksonVersion = "2.6.0"
+  private val jacksonVersion = "2.6.1"
 
   val `jackson-annotations` = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
   val `jackson-core` = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
@@ -26,13 +26,13 @@ trait json {
 }
 
 trait http {
-  val `async-http-client-1.8` = "com.ning" % "async-http-client" % "1.8.7"
-  val `async-http-client-1.9` = "com.ning" % "async-http-client" % "1.9.18"
-  val `apache-httpasyncclient` = "org.apache.httpcomponents" % "httpasyncclient" % "4.0.2"
+  val `async-http-client-1.8` = "com.ning" % "async-http-client" % "1.8.16"
+  val `async-http-client-1.9` = "com.ning" % "async-http-client" % "1.9.30"
+  val `apache-httpasyncclient` = "org.apache.httpcomponents" % "httpasyncclient" % "4.1"
 }
 
 trait other {
-  val `nv-i18n` = "com.neovisionaries" % "nv-i18n" % "1.15"
+  val `nv-i18n` = "com.neovisionaries" % "nv-i18n" % "1.17"
   val `commons-lang3` = "org.apache.commons" % "commons-lang3" % "3.4"
   val `commons-io` = "org.apache.commons" % "commons-io" % "1.3.2"
   val `moneta` = "org.javamoney" % "moneta" % "1.0"
@@ -45,7 +45,7 @@ trait other {
 
 trait test {
   val `junit-dep` = "junit" % "junit-dep" % "4.11"
-  val assertj =  "org.assertj" % "assertj-core" % "3.0.0"
+  val assertj =  "org.assertj" % "assertj-core" % "3.1.0"
   val `junit-interface` = "com.novocode" % "junit-interface" % "0.11"
 
   val allTestLibs =


### PR DESCRIPTION
@lauraluiz please review

@nkuehn @hajoeichler @lauraluiz 

To say it in other words: If everything works fine I will update the production code dependencies next time for the next major release (2.0.0). So that will maybe in half a year or next year.
I would like to keep the current dependencies for stability reasons. I won't update it to be up to date and put migration problems on the users.

If ning Async HTTP Client 2.0.0 will be released, I just create a new module sdk http client module which can be pulled.