### PR TITLE
Retry quadratically

### DIFF
--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchFilterTypesIntegrationTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchFilterTypesIntegrationTest.java
@@ -97,7 +97,7 @@ public class ProductProjectionSearchFilterTypesIntegrationTest extends Integrati
     public static final ZonedDateTime DATE_TIME_2002_23H = ZonedDateTime.parse("2002-10-12T23:06:10.204+00:00");
 
     @Rule
-    public RetryIntegrationTest retry = new RetryIntegrationTest(10, 0, LoggerFactory.getLogger(this.getClass()));
+    public RetryIntegrationTest retry = new RetryIntegrationTest(10, 10000, LoggerFactory.getLogger(this.getClass()));
 
     @BeforeClass
     public static void setupProducts() {

--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductProjectionSearchIntegrationTest.java
@@ -63,7 +63,7 @@ public class ProductProjectionSearchIntegrationTest extends IntegrationTest {
     public static final String ATTR_NAME_EVIL = ("Evil" + TEST_CLASS_NAME).substring(0, min(20, TEST_CLASS_NAME.length()));
 
     @Rule
-    public RetryIntegrationTest retry = new RetryIntegrationTest(10, 0, LoggerFactory.getLogger(this.getClass()));
+    public RetryIntegrationTest retry = new RetryIntegrationTest(10, 10000, LoggerFactory.getLogger(this.getClass()));
 
     @BeforeClass
     public static void setupProducts() {


### PR DESCRIPTION
@schleichardt please review. It is just an improvement of the retry method, which now increases the delay quadratically until it reaches the maximum retry interval specified. This way we might save some time when it fails due to unsynchronized resources.

I then allowed up to 10 seconds of retry. I may lower this if I see it is not necessary, but actually if it is really unnecessary it should never have to wait that much :)