### PR TITLE
Split URL before query string, closes #802

### DIFF
--- a/sphere-common/src/main/java/io/sphere/sdk/utils/SphereInternalLogger.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/utils/SphereInternalLogger.java
@@ -126,7 +126,7 @@ public final class SphereInternalLogger {
 
     private static String getPathElement(final HttpRequest httpRequest) {
         final String path = httpRequest.getUrl();
-        final String[] pathElements = path.split("/");
+        final String[] pathElements = path.split("[\\/\\?]");
         return pathElements.length >= 5 ? pathElements[4] : "project";
     }
 


### PR DESCRIPTION
Currently we are getting defined loggers such as:
```
sphere.customer-groups?where=name%3D%22b2c%22.responses.queries
```
With this fix we would get instead:
```
sphere.customer-groups.responses.queries
```