### PR TITLE
Fix missing Content-Length in AHC. close #799

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -50,7 +50,8 @@ object Build extends Build {
     .settings(libraryDependencies ++= allTestLibs.map(_ % "test,it"))
 
   lazy val `sphere-java-client-internal-test` = project.dependsOn(`sphere-java-client-core`).settings(commonSettings:_*).settings(
-    libraryDependencies ++= allTestLibs
+    libraryDependencies ++= allTestLibs,
+    libraryDependencies += `commons-io`
   ).configs(IntegrationTest)
 
   lazy val `sphere-java-client` = project.configs(IntegrationTest).dependsOn(`sphere-java-client-ahc-1_9`).settings(commonSettings:_*)
@@ -65,7 +66,7 @@ object Build extends Build {
     .settings().configs(IntegrationTest)
 
   lazy val `sdk-http-ahc-1_8` = project.configs(IntegrationTest).dependsOn(`sdk-http`, `sphere-java-client-internal-test` % "test,it").settings(commonSettings:_*)
-    .settings(libraryDependencies += `async-http-client-1.8`).configs(IntegrationTest)
+    .settings(libraryDependencies ++= Seq(`async-http-client-1.8`, `commons-io`)).configs(IntegrationTest)
 
   lazy val `sdk-http-ahc-1_9` = project.configs(IntegrationTest).dependsOn(`sdk-http`, `sphere-java-client-internal-test` % "test,it").settings(commonSettings:_*)
     .settings(libraryDependencies += `async-http-client-1.9`).configs(IntegrationTest)

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -34,7 +34,7 @@ trait http {
 trait other {
   val `nv-i18n` = "com.neovisionaries" % "nv-i18n" % "1.17"
   val `commons-lang3` = "org.apache.commons" % "commons-lang3" % "3.4"
-  val `commons-io` = "org.apache.commons" % "commons-io" % "1.3.2"
+  val `commons-io` = "commons-io" % "commons-io" % "2.4"
   val `moneta` = "org.javamoney" % "moneta" % "1.0"
   val `slf4j-api` = "org.slf4j" % "slf4j-api" % "1.7.12"
   val `logback-classic` = "ch.qos.logback" % "logback-classic" % "1.1.3"

--- a/sdk-http-ahc-1_9/src/main/java/io/sphere/sdk/http/DefaultAsyncHttpClientAdapterImpl.java
+++ b/sdk-http-ahc-1_9/src/main/java/io/sphere/sdk/http/DefaultAsyncHttpClientAdapterImpl.java
@@ -69,7 +69,7 @@ final class DefaultAsyncHttpClientAdapterImpl implements AsyncHttpClientAdapter 
                 .setUrl(request.getUrl())
                 .setMethod(request.getHttpMethod().toString());
 
-        request.getHeaders().getHeadersAsMap().forEach((name, values) -> values.forEach( value -> builder.addHeader(name, value)));
+        request.getHeaders().getHeadersAsMap().forEach((name, values) -> values.forEach(value -> builder.addHeader(name, value)));
 
         Optional.ofNullable(request.getBody()).ifPresent(body -> {
             if (body instanceof StringHttpRequestBody) {
@@ -78,7 +78,7 @@ final class DefaultAsyncHttpClientAdapterImpl implements AsyncHttpClientAdapter 
             } else if (body instanceof FileHttpRequestBody) {
                 builder.setBody(((FileHttpRequestBody) body).getFile());
             } else if (body instanceof FormUrlEncodedHttpRequestBody) {
-                ((FormUrlEncodedHttpRequestBody) body).getData().forEach((name, value) -> builder.addQueryParam(name, value));
+                ((FormUrlEncodedHttpRequestBody) body).getData().forEach((name, value) -> builder.addFormParam(name, value));
             }
         });
         final Request build = builder.build();

--- a/sdk-http/src/main/java/io/sphere/sdk/http/HttpHeaders.java
+++ b/sdk-http/src/main/java/io/sphere/sdk/http/HttpHeaders.java
@@ -8,6 +8,7 @@ public class HttpHeaders extends Base {
     public static final String AUTHORIZATION = "Authorization";
     public static final String USER_AGENT = "User-Agent";
     public static final String CONTENT_TYPE = "Content-Type";
+    public static final String CONTENT_LENGTH = "Content-Length";
     private final Map<String, List<String>> headers;
 
     private HttpHeaders(final Map<String, List<String>> headers) {

--- a/sphere-java-client-ahc-1_8/src/it/java/io/sphere/sdk/client/AsyncHttpClientAdapter18Test.java
+++ b/sphere-java-client-ahc-1_8/src/it/java/io/sphere/sdk/client/AsyncHttpClientAdapter18Test.java
@@ -4,9 +4,14 @@ import com.ning.http.client.AsyncHttpClient;
 import io.sphere.sdk.http.HttpClient;
 import io.sphere.sdk.http.AsyncHttpClientAdapter;
 
-public class AsyncHttpClientAdapterTest extends HttpClientAdapterTest {
+public class AsyncHttpClientAdapter18Test extends HttpClientAdapterTest {
     @Override
     protected HttpClient createClient() {
         return AsyncHttpClientAdapter.of(new AsyncHttpClient());
+    }
+
+    @Override
+    protected int port() {
+        return 5013;
     }
 }

--- a/sphere-java-client-ahc-1_9/src/it/java/io/sphere/sdk/client/AsyncHttpClientAdapter19Test.java
+++ b/sphere-java-client-ahc-1_9/src/it/java/io/sphere/sdk/client/AsyncHttpClientAdapter19Test.java
@@ -4,9 +4,14 @@ import com.ning.http.client.AsyncHttpClient;
 import io.sphere.sdk.http.HttpClient;
 import io.sphere.sdk.http.AsyncHttpClientAdapter;
 
-public class AsyncHttpClientAdapterTest extends HttpClientAdapterTest {
+public class AsyncHttpClientAdapter19Test extends HttpClientAdapterTest {
     @Override
     protected HttpClient createClient() {
         return AsyncHttpClientAdapter.of(new AsyncHttpClient());
+    }
+
+    @Override
+    protected int port() {
+        return 5012;
     }
 }

--- a/sphere-java-client-apache-async/src/it/java/io/sphere/sdk/client/ApacheHttpClientAdapterTest.java
+++ b/sphere-java-client-apache-async/src/it/java/io/sphere/sdk/client/ApacheHttpClientAdapterTest.java
@@ -9,4 +9,9 @@ public class ApacheHttpClientAdapterTest extends HttpClientAdapterTest {
     protected HttpClient createClient() {
         return ApacheHttpClientAdapter.of(HttpAsyncClients.createDefault());
     }
+
+    @Override
+    protected int port() {
+        return 5014;
+    }
 }

--- a/sphere-java-client-internal-test/src/main/java/io/sphere/sdk/client/HttpClientAdapterTest.java
+++ b/sphere-java-client-internal-test/src/main/java/io/sphere/sdk/client/HttpClientAdapterTest.java
@@ -1,16 +1,27 @@
 package io.sphere.sdk.client;
 
-import io.sphere.sdk.http.HttpClient;
-import io.sphere.sdk.http.HttpMethod;
-import io.sphere.sdk.http.HttpRequest;
-import io.sphere.sdk.http.HttpResponse;
+import io.sphere.sdk.http.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class HttpClientAdapterTest {
 
     protected abstract HttpClient createClient();
+    protected abstract int port();
 
     @Test
     public final void testConnection() {
@@ -20,5 +31,72 @@ public abstract class HttpClientAdapterTest {
         final String body = new String(response.getResponseBody());
         assertThat(response.getStatusCode()).isLessThan(400);
         assertThat(body).containsIgnoringCase("commercetools");
+    }
+
+    @Test
+    public final void stringBody() throws Exception {
+        final String bodyData = "123456789";
+        final HttpRequestBody requestBody = StringHttpRequestBody.of(bodyData);
+        final int length = bodyData.length();
+        checkBodyRequest(port(), requestBody, length);
+    }
+
+    @Test
+    public final void fileBody() throws Exception {
+        final String bodyData = "123456789";
+
+        final File file = File.createTempFile(RandomStringUtils.randomAlphanumeric(32), "ext");
+        FileUtils.writeStringToFile(file, bodyData);
+        file.deleteOnExit();
+
+        final HttpRequestBody requestBody = FileHttpRequestBody.of(file);
+        final int length = bodyData.length();
+        checkBodyRequest(port() + 100, requestBody, length);
+    }
+
+    @Test
+    public final void formEncodedBody() throws Exception {
+        final Map<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+
+        final HttpRequestBody requestBody = FormUrlEncodedHttpRequestBody.of(map);
+        final int length = 11;
+
+        checkBodyRequest(port() + 200, requestBody, length);
+    }
+
+    private void checkBodyRequest(final int port, final HttpRequestBody requestBody, final int length) throws Exception {
+        final ServerSocket serverSocket = new ServerSocket(port);
+        final CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            final StringBuilder stringBuilder = new StringBuilder();
+            try (final Socket socket = serverSocket.accept()){
+                String inputLine;
+                final BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+                //important: the input stream does not contain data and is then closed
+                //the tcp connection is still active and just contains no new data
+                //with org.apache.commons.io.IOUtils.toString(java.io.InputStream) it would block forever
+                while ((inputLine = in.readLine()) != null
+                        //HTTP headers end with empty line
+                        && !inputLine.isEmpty()) {
+                    stringBuilder.append(inputLine).append("\n");
+                }
+                final OutputStream outputStream = socket.getOutputStream();
+                IOUtils.write("HTTP/1.0 200 OK\r\n\r\n", outputStream);
+                outputStream.flush();
+                outputStream.close();
+                in.close();
+                return stringBuilder.toString();
+            } catch (IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+        Thread.sleep(100);
+        final HttpClient client = createClient();
+        final HttpRequest httpRequest = HttpRequest.of(HttpMethod.POST, "http://localhost:" + port, HttpHeaders.of("foo", "bar"), requestBody);
+        final HttpResponse response = client.execute(httpRequest).toCompletableFuture().get(15, TimeUnit.SECONDS);
+        client.close();
+        final String receivedHttpHeadersAndBody = future.join();
+        LoggerFactory.getLogger(HttpClientAdapterTest.class).info(receivedHttpHeadersAndBody);
+        assertThat(receivedHttpHeadersAndBody).contains("Content-Length: " + length);
     }
 }


### PR DESCRIPTION
@lauraluiz please review

@panshul007 Can you please try out a snapshot if it works for you? The version number is "1.0.0-M20-issue-799-SNAPSHOT"

You may need to add the sonatype snapshots resolver:

```
resolvers ++= Seq (
    Resolver.sonatypeRepo("releases"),
    Resolver.sonatypeRepo("snapshots"),
    Resolver.bintrayRepo("commercetools", "maven")
  )
```