### PR TITLE
Change query sort DSL. close #764

### DIFF
--- a/sphere-common/src/main/java/io/sphere/sdk/queries/DirectionlessQuerySort.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/DirectionlessQuerySort.java
@@ -13,18 +13,18 @@ public class DirectionlessQuerySort<T> extends Base {
     }
 
     public QuerySort<T> asc() {
-        return getQuerySort(ASC);
+        return by(ASC);
     }
 
     public QuerySort<T> desc() {
-        return getQuerySort(DESC);
+        return by(DESC);
     }
 
     public static <T> DirectionlessQuerySort<T> of(final QueryModel<T> path) {
         return new DirectionlessQuerySort<>(path);
     }
 
-    private QuerySort<T> getQuerySort(final QuerySortDirection direction) {
+    public QuerySort<T> by(final QuerySortDirection direction) {
         return new SphereQuerySort<>(path, direction);
     }
 }

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/IntegerLikeQuerySortingModel.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/IntegerLikeQuerySortingModel.java
@@ -16,6 +16,7 @@ abstract class IntegerLikeQuerySortingModel<T, V> extends QueryModelImpl<T>
         super(parent, pathSegment);
     }
 
+    @Deprecated
     @Override
     public QuerySort<T> sort(final QuerySortDirection sortDirection) {
         return new SphereQuerySort<>(this, sortDirection);

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/IntegerQuerySortingModel.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/IntegerQuerySortingModel.java
@@ -31,6 +31,7 @@ public interface IntegerQuerySortingModel<T> extends QueryModel<T>, QuerySorting
     @Override
     QueryPredicate<T> isPresent();
 
+    @Deprecated
     @Override
     QuerySort<T> sort(QuerySortDirection sortDirection);
 }

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/LongQuerySortingModel.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/LongQuerySortingModel.java
@@ -31,6 +31,7 @@ public interface LongQuerySortingModel<T> extends QueryModel<T>, QuerySortingMod
     @Override
     QueryPredicate<T> isPresent();
 
+    @Deprecated
     @Override
     QuerySort<T> sort(QuerySortDirection sortDirection);
 }

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/QuerySortingModel.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/QuerySortingModel.java
@@ -1,6 +1,13 @@
 package io.sphere.sdk.queries;
 
 public interface QuerySortingModel<T> {
+    /**
+     * Use {@link #sort()} instead.
+     *
+     * @param sortDirection the direction to sort with
+     * @return query sort
+     */
+    @Deprecated
     QuerySort<T> sort(final QuerySortDirection sortDirection);
 
     DirectionlessQuerySort<T> sort();

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/StringQuerySortingModel.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/StringQuerySortingModel.java
@@ -1,6 +1,7 @@
 package io.sphere.sdk.queries;
 
 public interface StringQuerySortingModel<T> extends QuerySortingModel<T>, StringQueryModel<T> {
+    @Deprecated
     @Override
     QuerySort<T> sort(QuerySortDirection sortDirection);
 

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/StringQuerySortingModelImpl.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/StringQuerySortingModelImpl.java
@@ -11,6 +11,7 @@ final class StringQuerySortingModelImpl<T> extends QueryModelImpl<T> implements 
         super(parent, pathSegment);
     }
 
+    @Deprecated
     @Override
     public QuerySort<T> sort(final QuerySortDirection sortDirection) {
         return new SphereQuerySort<>(this, sortDirection);

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/TimestampSortingModel.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/TimestampSortingModel.java
@@ -1,6 +1,7 @@
 package io.sphere.sdk.queries;
 
 public interface TimestampSortingModel<T> extends QuerySortingModel<T> {
+    @Deprecated
     @Override
     QuerySort<T> sort(QuerySortDirection sortDirection);
 

--- a/sphere-common/src/main/java/io/sphere/sdk/queries/TimestampSortingModelImpl.java
+++ b/sphere-common/src/main/java/io/sphere/sdk/queries/TimestampSortingModelImpl.java
@@ -7,6 +7,7 @@ final class TimestampSortingModelImpl<T> extends QueryModelImpl<T> implements Ti
         super(parent, pathSegment);
     }
 
+    @Deprecated
     @Override
     public QuerySort<T> sort(final QuerySortDirection sortDirection) {
         return new SphereQuerySort<>(this, sortDirection);

--- a/sphere-common/src/test/java/io/sphere/sdk/queries/StringQuerySortingModelTest.java
+++ b/sphere-common/src/test/java/io/sphere/sdk/queries/StringQuerySortingModelTest.java
@@ -40,7 +40,12 @@ public class StringQuerySortingModelTest {
     }
 
     @Test
-    public void generateSortExpression() throws Exception {
-        assertThat(model.sort(ASC).toSphereSort()).isEqualTo("id asc");
+    public void generateSortExpressionAsc() throws Exception {
+        assertThat(model.sort().asc().toSphereSort()).isEqualTo("id asc");
+    }
+
+    @Test
+    public void generateSortExpressionDesc() throws Exception {
+        assertThat(model.sort().desc().toSphereSort()).isEqualTo("id desc");
     }
 }

--- a/sphere-models/src/it/java/io/sphere/sdk/categories/queries/CategoryQueryTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/categories/queries/CategoryQueryTest.java
@@ -49,7 +49,7 @@ public class CategoryQueryTest extends IntegrationTest {
             withCategory(client(), category2 -> {
                 final Query<Category> query = CategoryQuery.of().
                         withPredicates(m -> m.name().lang(Locale.ENGLISH).isNot(category1.getName().get(Locale.ENGLISH)))
-                        .withSort(m -> m.createdAt().sort(DESC));
+                        .withSort(m -> m.createdAt().sort().desc());
                 final boolean category1IsPresent = execute(query).getResults().stream().anyMatch(cat -> cat.getId().equals(category1.getId()));
                 assertThat(category1IsPresent).isFalse();
             })
@@ -66,7 +66,7 @@ public class CategoryQueryTest extends IntegrationTest {
                                     m.name().lang(Locale.ENGLISH).is(category1.getName().get(Locale.ENGLISH)).negate();
                             return predicate;
                         })
-                        .withSort(m -> m.createdAt().sort(DESC));
+                        .withSort(m -> m.createdAt().sort().desc());
                 final boolean category1IsPresent = execute(query).getResults().stream().anyMatch(cat -> cat.getId().equals(category1.getId()));
                 assertThat(category1IsPresent).isFalse();
             })
@@ -84,7 +84,7 @@ public class CategoryQueryTest extends IntegrationTest {
                                             .and(m.id().is(category1.getId()));
                             return predicate;
                         })
-                        .withSort(m -> m.createdAt().sort(DESC));
+                        .withSort(m -> m.createdAt().sort().desc());
                 final boolean category1IsPresent = execute(query).getResults().stream().anyMatch(cat -> cat.getId().equals(category1.getId()));
                 assertThat(category1IsPresent).isFalse();
             })

--- a/sphere-models/src/it/java/io/sphere/sdk/customobjects/queries/CustomObjectQueryTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/customobjects/queries/CustomObjectQueryTest.java
@@ -67,7 +67,7 @@ public class CustomObjectQueryTest extends IntegrationTest {
     }
 
     public void demoModelTypeParameter() {
-        final QuerySort<CustomObject<JsonNode>> sort = CustomObjectQueryModel.<CustomObject<JsonNode>>of().createdAt().sort(DESC);
-        final QuerySort<CustomObject<Foo>> fooSort = CustomObjectQueryModel.<CustomObject<Foo>>of().createdAt().sort(DESC);
+        final QuerySort<CustomObject<JsonNode>> sort = CustomObjectQueryModel.<CustomObject<JsonNode>>of().createdAt().sort().desc();
+        final QuerySort<CustomObject<Foo>> fooSort = CustomObjectQueryModel.<CustomObject<Foo>>of().createdAt().sort().desc();
     }
 }

--- a/sphere-models/src/it/java/io/sphere/sdk/inventory/queries/InventoryEntryQueryTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/inventory/queries/InventoryEntryQueryTest.java
@@ -48,7 +48,7 @@ public class InventoryEntryQueryTest extends IntegrationTest {
                 final QueryPredicate<InventoryEntry> predicate = skuP.and(channelP).and(channelPById).and(availableP).and(stockP).and(restockableInDaysP);
                 final Query<InventoryEntry> query = InventoryEntryQuery.of()
                         .withPredicates(predicate)
-                        .withSort(m -> m.id().sort(QuerySortDirection.DESC))
+                        .withSort(m -> m.id().sort().desc())
                         .withExpansionPaths(m -> m.supplyChannel());
                 final PagedQueryResult<InventoryEntry> result = execute(query);
                 assertThat(result.head().map(e -> e.getId())).contains(entry.getId());

--- a/sphere-models/src/it/java/io/sphere/sdk/products/queries/ProductProjectionQueryTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/queries/ProductProjectionQueryTest.java
@@ -189,7 +189,7 @@ public class ProductProjectionQueryTest extends IntegrationTest {
             final Product updated = execute(ProductUpdateCommand.of(product, ChangeName.of(randomSlug())));
             final PagedQueryResult<ProductProjection> pagedQueryResult = execute(ProductProjectionQuery.of(STAGED)
                     .withPredicates(m -> m.hasStagedChanges().is(true))
-                    .withSort(m -> m.createdAt().sort(DESC)));
+                    .withSort(m -> m.createdAt().sort().desc()));
             assertThat(ids(pagedQueryResult)).contains(updated.getId());
         });
     }

--- a/sphere-models/src/it/java/io/sphere/sdk/shippingmethods/queries/ShippingMethodQueryModelTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/shippingmethods/queries/ShippingMethodQueryModelTest.java
@@ -5,13 +5,12 @@ import io.sphere.sdk.shippingmethods.ShippingMethod;
 import io.sphere.sdk.test.IntegrationTest;
 import org.junit.Test;
 
-import static io.sphere.sdk.queries.QuerySortDirection.DESC;
 import static io.sphere.sdk.shippingmethods.ShippingMethodFixtures.withShippingMethod;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ShippingMethodQueryModelTest extends IntegrationTest {
 
-    public static final QuerySort<ShippingMethod> BY_CREATED_AT_DESC = ShippingMethodQueryModel.of().createdAt().sort(DESC);
+    public static final QuerySort<ShippingMethod> BY_CREATED_AT_DESC = ShippingMethodQueryModel.of().createdAt().sort().desc();
 
     @Test
     public void queryByName() throws Exception {

--- a/sphere-models/src/test/java/io/sphere/sdk/orders/queries/SyncInfoQueryModelTest.java
+++ b/sphere-models/src/test/java/io/sphere/sdk/orders/queries/SyncInfoQueryModelTest.java
@@ -2,13 +2,12 @@ package io.sphere.sdk.orders.queries;
 
 import org.junit.Test;
 
-import static io.sphere.sdk.queries.QuerySortDirection.ASC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SyncInfoQueryModelTest {
     @Test
     public void sortBySyncedAt() throws Exception {
-        assertThat(OrderQueryModel.of().syncInfo().syncedAt().sort(ASC).toSphereSort())
+        assertThat(OrderQueryModel.of().syncInfo().syncedAt().sort().asc().toSphereSort())
         .isEqualTo("syncInfo.syncedAt asc");
     }
 }

--- a/src/test/java/io/sphere/sdk/meta/QueryDocumentationTest.java
+++ b/src/test/java/io/sphere/sdk/meta/QueryDocumentationTest.java
@@ -11,12 +11,12 @@ import io.sphere.sdk.products.expansion.ProductProjectionExpansionModel;
 import io.sphere.sdk.products.queries.ProductProjectionQuery;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.products.queries.ProductQueryModel;
-import io.sphere.sdk.queries.*;
+import io.sphere.sdk.queries.QueryPredicate;
+import io.sphere.sdk.queries.QuerySort;
 import org.junit.Test;
 
 import static io.sphere.sdk.products.ProductProjectionType.CURRENT;
 import static io.sphere.sdk.products.ProductProjectionType.STAGED;
-import static io.sphere.sdk.queries.QuerySortDirection.ASC;
 import static io.sphere.sdk.queries.QuerySortDirection.DESC;
 import static java.util.Arrays.asList;
 import static java.util.Locale.ENGLISH;
@@ -94,21 +94,21 @@ public class QueryDocumentationTest {
 
     public void sortByName() {
         final QuerySort<Product> byNameAsc = ProductQueryModel.of().masterData().current().name()
-                .lang(ENGLISH).sort(ASC);
+                .lang(ENGLISH).sort().asc();
         final ProductQuery query = ProductQuery.of().withSort(asList(byNameAsc));
     }
 
     public void sortByNameAscAndIdDesc() {
         final QuerySort<Product> byNameAsc = ProductQueryModel.of().masterData().current().name()
-                .lang(ENGLISH).sort(ASC);
-        final QuerySort<Product> byIdDesc = ProductQueryModel.of().id().sort(DESC);
+                .lang(ENGLISH).sort().asc();
+        final QuerySort<Product> byIdDesc = ProductQueryModel.of().id().sort().by(DESC);
         final ProductQuery query = ProductQuery.of().withSort(asList(byNameAsc, byIdDesc));
     }
 
     @Test
     public void sortCreationByString() {
         final QuerySort<Product> safeSort = ProductQueryModel.of().masterData().current().name()
-                .lang(ENGLISH).sort(ASC);
+                .lang(ENGLISH).sort().asc();
         final QuerySort<Product> unsafeSort = QuerySort.of("masterData.current.name.en asc");
         assertThat(safeSort).isEqualTo(unsafeSort);
     }

--- a/src/test/java/io/sphere/sdk/queries/QueryDemo.java
+++ b/src/test/java/io/sphere/sdk/queries/QueryDemo.java
@@ -47,8 +47,8 @@ public class QueryDemo {
     private void withPagination() {
         QueryPredicate<Category> predicate = CategoryQueryModel.of().name().lang(locale).is("demo cat");
 
-        QuerySort<Category> sortByName = CategoryQueryModel.of().name().lang(locale).sort(QuerySortDirection.DESC);
-        QuerySort<Category> sortById = CategoryQueryModel.of().id().sort(QuerySortDirection.ASC);
+        QuerySort<Category> sortByName = CategoryQueryModel.of().name().lang(locale).sort().desc();
+        QuerySort<Category> sortById = CategoryQueryModel.of().id().sort().asc();
         List<QuerySort<Category>> sort = Arrays.asList(sortByName, sortById);//sort by name desc and then by ID if name is the same
 
         int offset = 1;//skip first page


### PR DESCRIPTION
@lauraluiz please review.

With this PR I want to make it more fluent to create sort expressions by removing the need to lookup the constants or make imports. Maybe we should rename DirectionlessQuerySort.