### PR TITLE
Put Category Order Hints to sort search model. close #794

### DIFF
--- a/sphere-models/src/it/java/io/sphere/sdk/products/ProductCategoryOrderHintTest.java
+++ b/sphere-models/src/it/java/io/sphere/sdk/products/ProductCategoryOrderHintTest.java
@@ -8,7 +8,6 @@ import io.sphere.sdk.products.queries.ProductProjectionQuery;
 import io.sphere.sdk.products.search.ProductProjectionSearch;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeFixtures;
-import io.sphere.sdk.search.SortExpression;
 import io.sphere.sdk.test.IntegrationTest;
 import org.assertj.core.api.Condition;
 import org.junit.AfterClass;
@@ -243,7 +242,7 @@ public class ProductCategoryOrderHintTest extends IntegrationTest {
     private static List<ProductProjection> searchForCategoryAndSort(final String categoryId) {
         final ProductProjectionSearch searchRequest = ProductProjectionSearch.ofStaged()
                 .withQueryFilters(filter -> filter.categories().id().by(categoryId))
-                .withSort(SortExpression.of("categoryOrderHints." + categoryId + " asc"));
+                .withSort(m -> m.categoryOrderHints().category(categoryId).byAsc());
         return execute(searchRequest).getResults();
     }
 

--- a/sphere-models/src/main/java/io/sphere/sdk/products/search/CategoryOrderHintsSortSearchModel.java
+++ b/sphere-models/src/main/java/io/sphere/sdk/products/search/CategoryOrderHintsSortSearchModel.java
@@ -1,0 +1,16 @@
+package io.sphere.sdk.products.search;
+
+import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.search.model.*;
+
+import javax.annotation.Nullable;
+
+public class CategoryOrderHintsSortSearchModel extends SortableSearchModel<ProductProjection, SingleValueSortSearchModel<ProductProjection>> {
+    CategoryOrderHintsSortSearchModel(@Nullable final SearchModel<ProductProjection> parent, @Nullable final String pathSegment) {
+        super(parent, pathSegment, SingleValueSortSearchModelFactory.of());
+    }
+
+    public SingleValueSortSearchModel<ProductProjection> category(final String categoryId) {
+        return searchModel(categoryId).sorted();
+    }
+}

--- a/sphere-models/src/main/java/io/sphere/sdk/products/search/ProductDataSortSearchModel.java
+++ b/sphere-models/src/main/java/io/sphere/sdk/products/search/ProductDataSortSearchModel.java
@@ -26,4 +26,8 @@ public class ProductDataSortSearchModel extends SortableSearchModel<ProductProje
     public SingleValueSortSearchModel<ProductProjection> lastModifiedAt() {
         return searchModel("lastModifiedAt").sorted();
     }
+
+    public CategoryOrderHintsSortSearchModel categoryOrderHints() {
+        return new CategoryOrderHintsSortSearchModel(this, "categoryOrderHints");
+    }
 }

--- a/sphere-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionSortSearchModel.java
+++ b/sphere-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionSortSearchModel.java
@@ -35,4 +35,9 @@ public class ProductProjectionSortSearchModel extends ProductDataSortSearchModel
     public SingleValueSortSearchModel<ProductProjection> lastModifiedAt() {
         return super.lastModifiedAt();
     }
+
+    @Override
+    public CategoryOrderHintsSortSearchModel categoryOrderHints() {
+        return super.categoryOrderHints();
+    }
 }


### PR DESCRIPTION
@lauraluiz please review

In ProductCategoryOrderHintTest was already a good place for the meta model usage.