### PR TITLE
rename and open LocalizedToStringProductAttributeConverter, close #992

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -28,8 +28,6 @@ import io.sphere.sdk.products.*;
 import io.sphere.sdk.products.attributes.Attribute;
 import io.sphere.sdk.products.attributes.AttributeAccess;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
-import io.sphere.sdk.products.attributes.LocalizedToStringProductAttributeConverter;
-import io.sphere.sdk.products.commands.ProductCreateCommand;
 import io.sphere.sdk.products.commands.updateactions.SetMetaDescription;
 import io.sphere.sdk.products.commands.updateactions.SetMetaKeywords;
 import io.sphere.sdk.products.commands.updateactions.SetMetaTitle;
@@ -153,7 +151,7 @@ import java.util.function.Function;
  <li class=new-in-release>Added {@link Project#getCurrencies()} and {@link Project#getCurrencyUnits()} so you can get your enabled currencies for the commercetools project.</li>
 
  <li class=new-in-release>Added some short hand methods for the work with product attributes like {@link Attribute#getValueAsLong()} and {@link Attribute#getValueAsString()}. For all see {@link Attribute}.</li>
- <li class=new-in-release>Added {@link LocalizedToStringProductAttributeConverter} which provides some defaults to present product attribute (including monetary amounts and date) values as String. The behaviour can be changed through subclasses.</li>
+ <li class=new-in-release>Added {@code LocalizedToStringProductAttributeConverter} which provides some defaults to present product attribute (including monetary amounts and date) values as String. The behaviour can be changed through subclasses.</li>
  </ul>
 
 

--- a/commercetools-internal-docs/src/test/java/io/sphere/sdk/meta/M26Demo.java
+++ b/commercetools-internal-docs/src/test/java/io/sphere/sdk/meta/M26Demo.java
@@ -2,12 +2,8 @@ package io.sphere.sdk.meta;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.sphere.sdk.customobjects.queries.CustomObjectQuery;
-import io.sphere.sdk.products.attributes.Attribute;
-import io.sphere.sdk.products.attributes.AttributeAccess;
-import io.sphere.sdk.products.attributes.LocalizedToStringProductAttributeConverter;
 import io.sphere.sdk.products.search.ProductProjectionSearch;
 import io.sphere.sdk.products.search.ProductProjectionSearchBuilder;
-import io.sphere.sdk.utils.MoneyImpl;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/AttributeExtraction.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/AttributeExtraction.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 /**
  * Helper class to create mapping from product attribute values to a target type.
  *
- * <p>This is a functional approach, {@link LocalizedToStringProductAttributeConverter} provides an object oriented way to achieve the same.</p>
+ * <p>This is a functional approach, {@link DefaultProductAttributeFormatter} provides an object oriented way to achieve the same.</p>
  *
  * <p>A possible use case is documented <a href="{@docRoot}/io/sphere/sdk/meta/ProductAttributeDocumentation.html#attribute-table-creation">here</a>.</p>
  *

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/DefaultProductAttributeFormatter.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/DefaultProductAttributeFormatter.java
@@ -22,21 +22,22 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 
-public class LocalizedToStringProductAttributeConverter extends ProductAttributeConverterBase<String> implements ProductAttributeConverter<String> {
+public class DefaultProductAttributeFormatter extends ProductAttributeConverterBase<String> implements ProductAttributeConverter<String> {
     private final List<Locale> locales;
 
-    public LocalizedToStringProductAttributeConverter(final ProductTypeLocalRepository productTypes, final List<Locale> locales) {
+    public DefaultProductAttributeFormatter(final ProductTypeLocalRepository productTypes, final List<Locale> locales) {
         super(productTypes);
         this.locales = locales;
     }
 
-    public LocalizedToStringProductAttributeConverter(final Collection<ProductType> productTypes, final List<Locale> locales) {
+    public DefaultProductAttributeFormatter(final Collection<ProductType> productTypes, final List<Locale> locales) {
         this(ProductTypeLocalRepository.of(productTypes), locales);
     }
 
     /**
-     Formats a product attribute as String. The product type reference should be extracted using
-     {@link Product#getProductType()}.
+     Formats a product attribute as String. The product type reference is typically extracted using
+     {@link io.sphere.sdk.products.ProductProjection#getProductType()} or
+     {@link io.sphere.sdk.products.Product#getProductType()}.
 
      @param attribute the attribute which should be formatted
      @param productType the reference of the product type of this attribute, it is not necessary to expand the reference
@@ -46,6 +47,21 @@ public class LocalizedToStringProductAttributeConverter extends ProductAttribute
     @Override
     public String convert(final Attribute attribute, final Referenceable<ProductType> productType) {
         return super.convert(attribute, productType);
+    }
+
+    /**
+     Formats a product attribute as String, alias of {@link #convert(Attribute, Referenceable)}.
+     The product type reference is typically extracted using
+     {@link io.sphere.sdk.products.ProductProjection#getProductType()} or
+     {@link io.sphere.sdk.products.Product#getProductType()}.
+
+     @param attribute the attribute which should be formatted
+     @param productType the reference of the product type of this attribute, it is not necessary to expand the reference
+     @return formatted attribute or null
+     */
+    @Nullable
+    public String format(final Attribute attribute, final Referenceable<ProductType> productType) {
+        return convert(attribute, productType);
     }
 
     protected Locale locale() {

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/LocalizedToStringProductAttributeConverter.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/LocalizedToStringProductAttributeConverter.java
@@ -25,12 +25,12 @@ import static java.util.stream.Collectors.joining;
 public class LocalizedToStringProductAttributeConverter extends ProductAttributeConverterBase<String> implements ProductAttributeConverter<String> {
     private final List<Locale> locales;
 
-    protected LocalizedToStringProductAttributeConverter(final ProductTypeLocalRepository productTypes, final List<Locale> locales) {
+    public LocalizedToStringProductAttributeConverter(final ProductTypeLocalRepository productTypes, final List<Locale> locales) {
         super(productTypes);
         this.locales = locales;
     }
 
-    protected LocalizedToStringProductAttributeConverter(final Collection<ProductType> productTypes, final List<Locale> locales) {
+    public LocalizedToStringProductAttributeConverter(final Collection<ProductType> productTypes, final List<Locale> locales) {
         this(ProductTypeLocalRepository.of(productTypes), locales);
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/LocalizedToStringProductAttributeConverter.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/attributes/LocalizedToStringProductAttributeConverter.java
@@ -34,6 +34,20 @@ public class LocalizedToStringProductAttributeConverter extends ProductAttribute
         this(ProductTypeLocalRepository.of(productTypes), locales);
     }
 
+    /**
+     Formats a product attribute as String. The product type reference should be extracted using
+     {@link Product#getProductType()}.
+
+     @param attribute the attribute which should be formatted
+     @param productType the reference of the product type of this attribute, it is not necessary to expand the reference
+     @return formatted attribute or null
+     */
+    @Nullable
+    @Override
+    public String convert(final Attribute attribute, final Referenceable<ProductType> productType) {
+        return super.convert(attribute, productType);
+    }
+
     protected Locale locale() {
         return getLocales().get(0);
     }

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/attributes/DefaultProductAttributeFormatterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/attributes/DefaultProductAttributeFormatterIntegrationTest.java
@@ -19,7 +19,7 @@ import static java.util.Collections.singletonList;
 import static io.sphere.sdk.products.ProductsScenario1Fixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LocalizedToStringProductAttributeConverterIntegrationTest extends IntegrationTest {
+public class DefaultProductAttributeFormatterIntegrationTest extends IntegrationTest {
 
     private static ProductsScenario1Fixtures.Data data;
     private static Product product;
@@ -33,7 +33,7 @@ public class LocalizedToStringProductAttributeConverterIntegrationTest extends I
         data = ProductsScenario1Fixtures.createScenario(client());
         product = data.getProduct1();
         productType = data.getProductType();
-        numberAsIntegerMapper = new LocalizedToStringProductAttributeConverter(singletonList(productType), asList(Locale.GERMANY, Locale.ENGLISH)) {
+        numberAsIntegerMapper = new DefaultProductAttributeFormatter(singletonList(productType), asList(Locale.GERMANY, Locale.ENGLISH)) {
             @Override
             protected Collection<String> integerAttributes() {
                 return singletonList(ATTR_NAME_NUMBER);
@@ -44,7 +44,7 @@ public class LocalizedToStringProductAttributeConverterIntegrationTest extends I
                 return singleton(ATTR_NAME_NUMBER_SET);
             }
         };
-        numberAsLongMapper = new LocalizedToStringProductAttributeConverter(singletonList(productType), asList(Locale.GERMANY, Locale.ENGLISH)) {
+        numberAsLongMapper = new DefaultProductAttributeFormatter(singletonList(productType), asList(Locale.GERMANY, Locale.ENGLISH)) {
             @Override
             protected Collection<String> longAttributes() {
                 return singletonList(ATTR_NAME_NUMBER);
@@ -55,7 +55,7 @@ public class LocalizedToStringProductAttributeConverterIntegrationTest extends I
                 return singleton(ATTR_NAME_NUMBER_SET);
             }
         };
-        numberAsDoubleMapper = new LocalizedToStringProductAttributeConverter(singletonList(productType), asList(Locale.GERMANY, Locale.ENGLISH));
+        numberAsDoubleMapper = new DefaultProductAttributeFormatter(singletonList(productType), asList(Locale.GERMANY, Locale.ENGLISH));
     }
 
     @AfterClass


### PR DESCRIPTION
@lauraluiz please review

release notes:

```html
 <li class=change-in-release>rename {@code LocalizedToStringProductAttributeConverter} 
to {@link io.sphere.sdk.products.attributes.DefaultProductAttributeFormatter}</li>
 <li class=new-in-release>make constructors of 
{@link io.sphere.sdk.products.attributes.DefaultProductAttributeFormatter} public</li>
 <li class=new-in-release>add alias
 {@link io.sphere.sdk.products.attributes.DefaultProductAttributeFormatter#format(Attribute, Referenceable)}
 for
 {@link io.sphere.sdk.products.attributes.DefaultProductAttributeFormatter#convert(Attribute, Referenceable)}</li>
```