### PR TITLE
metrics improvements, close #995

### DIFF
--- a/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/MetricSphereRequest.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/MetricSphereRequest.java
@@ -38,7 +38,7 @@ final class MetricSphereRequest<T> extends SphereRequestDecorator<T> {
         final long stopTimestamp = System.currentTimeMillis();
         final long duration = stopTimestamp - startTimestamp;
         correlationId = httpResponse.getHeaders().findFlatHeader("X-Correlation-ID").orElse(null);
-        observable.notifyObservers(ObservedDeserializationDuration.of(duration, id, delegate, correlationId));
+        observable.notifyObservers(ObservedDeserializationDuration.of(duration, id, delegate, correlationId, httpResponse, result));
         return result;
     }
 

--- a/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/ObservedDeserializationDuration.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/ObservedDeserializationDuration.java
@@ -1,6 +1,7 @@
 package io.sphere.sdk.client.metrics;
 
 import io.sphere.sdk.client.SphereRequest;
+import io.sphere.sdk.http.HttpResponse;
 
 import javax.annotation.Nullable;
 
@@ -10,18 +11,38 @@ import javax.annotation.Nullable;
 public final class ObservedDeserializationDuration extends ObservedDurationBase {
     @Nullable
     private final String correlationId;
+    @Nullable
+    private final HttpResponse httpResponse;
+    @Nullable
+    private final Object result;
 
-    private ObservedDeserializationDuration(final String sphereRequestId, final SphereRequest<?> request, final long durationInMilliseconds, @Nullable final String correlationId) {
+    private ObservedDeserializationDuration(final String sphereRequestId, final SphereRequest<?> request, final long durationInMilliseconds, @Nullable final String correlationId, @Nullable final HttpResponse httpResponse, @Nullable final Object result) {
         super(sphereRequestId, request, durationInMilliseconds);
         this.correlationId = correlationId;
+        this.httpResponse = httpResponse;
+        this.result = result;
     }
 
     public static ObservedDeserializationDuration of(final long durationInMilliseconds, final String sphereRequestId, final SphereRequest<?> request, @Nullable final String correlationId) {
-        return new ObservedDeserializationDuration(sphereRequestId, request, durationInMilliseconds, correlationId);
+        return of(durationInMilliseconds, sphereRequestId, request, correlationId, null, null);
+    }
+
+    public static ObservedDeserializationDuration of(final long durationInMilliseconds, final String sphereRequestId, final SphereRequest<?> request, @Nullable final String correlationId, @Nullable final HttpResponse httpResponse, @Nullable final Object result) {
+        return new ObservedDeserializationDuration(sphereRequestId, request, durationInMilliseconds, correlationId, httpResponse, result);
     }
 
     @Nullable
     public String getCorrelationId() {
         return correlationId;
+    }
+
+    @Nullable
+    public HttpResponse getHttpResponse() {
+        return httpResponse;
+    }
+
+    @Nullable
+    public Object getResult() {
+        return result;
     }
 }

--- a/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/ObservedTotalDuration.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/ObservedTotalDuration.java
@@ -11,14 +11,34 @@ import javax.annotation.Nullable;
 public final class ObservedTotalDuration extends ObservedDurationBase {
     @Nullable
     private final String correlationId;
+    @Nullable
+    private final Object successResult;
+    @Nullable
+    private final Throwable errorResult;
 
-    private ObservedTotalDuration(final String sphereRequestId, final SphereRequest<?> request, final long durationInMilliseconds, @Nullable final String correlationId) {
+    private ObservedTotalDuration(final String sphereRequestId, final SphereRequest<?> request, final long durationInMilliseconds, @Nullable final String correlationId, final Object successResult, final Throwable errorResult) {
         super(sphereRequestId, request, durationInMilliseconds);
         this.correlationId = correlationId;
+        this.successResult = successResult;
+        this.errorResult = errorResult;
     }
 
     public static ObservedTotalDuration of(final long durationInMilliseconds, final String sphereRequestId, final SphereRequest<?> request, @Nullable final String correlationId) {
-        return new ObservedTotalDuration(sphereRequestId, request, durationInMilliseconds, correlationId);
+        return of(durationInMilliseconds, sphereRequestId, request, correlationId, null, null);
+    }
+
+    public static ObservedTotalDuration of(final long durationInMilliseconds, final String sphereRequestId, final SphereRequest<?> request, @Nullable final String correlationId, @Nullable final Object successResult, @Nullable final Throwable errorResult) {
+        return new ObservedTotalDuration(sphereRequestId, request, durationInMilliseconds, correlationId, successResult, errorResult);
+    }
+
+    @Nullable
+    public Throwable getErrorResult() {
+        return errorResult;
+    }
+
+    @Nullable
+    public Object getSuccessResult() {
+        return successResult;
     }
 
     @Nullable

--- a/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClient.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClient.java
@@ -35,7 +35,7 @@ public final class SimpleMetricsSphereClient extends SphereClientDecorator imple
         completionStage.whenComplete((nullableResult, nullableThrowable) -> {
             final long stopTimestamp = System.currentTimeMillis();
             final long duration = stopTimestamp - startTimestamp;
-            metricObservable.notifyObservers(ObservedTotalDuration.of(duration, id, sphereRequest, metricSphereRequest.getCorrelationId()));
+            metricObservable.notifyObservers(ObservedTotalDuration.of(duration, id, sphereRequest, metricSphereRequest.getCorrelationId(), nullableResult, nullableThrowable));
         });
         return completionStage;
     }

--- a/commercetools-convenience/src/test/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClientTest.java
+++ b/commercetools-convenience/src/test/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClientTest.java
@@ -30,7 +30,7 @@ public class SimpleMetricsSphereClientTest {
 
         metricClient.execute(ProjectGet.of()).toCompletableFuture().join();
         assertThat(Logger.getAndClear()).matches("observed: ObservedSerializationDuration\\[requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]\n" +
-                "observed: ObservedDeserializationDuration\\[correlationId=ID-123456,requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]\n" +
+                "observed: ObservedDeserializationDuration\\[correlationId=ID-123456,httpResponse=.*,result=.*,requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]\n" +
                 "observed: ObservedTotalDuration\\[correlationId=ID-123456,successResult=Project\\[key=<null>,name=<null>,countries=<null>,languages=<null>,currencies=<null>,createdAt=<null>,trialUntil=<null>\\],errorResult=<null>,requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]");
     }
 

--- a/commercetools-convenience/src/test/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClientTest.java
+++ b/commercetools-convenience/src/test/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClientTest.java
@@ -31,8 +31,10 @@ public class SimpleMetricsSphereClientTest {
         metricClient.execute(ProjectGet.of()).toCompletableFuture().join();
         assertThat(Logger.getAndClear()).matches("observed: ObservedSerializationDuration\\[requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]\n" +
                 "observed: ObservedDeserializationDuration\\[correlationId=ID-123456,requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]\n" +
-                "observed: ObservedTotalDuration\\[correlationId=ID-123456,requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]");
+                "observed: ObservedTotalDuration\\[correlationId=ID-123456,successResult=Project\\[key=<null>,name=<null>,countries=<null>,languages=<null>,currencies=<null>,createdAt=<null>,trialUntil=<null>\\],errorResult=<null>,requestId=1,durationInMilliseconds=\\d+,request=ProjectGet\\[\\]\\]");
     }
+
+
 
     @Test
     public void testAll() {
@@ -69,6 +71,8 @@ public class SimpleMetricsSphereClientTest {
         softly.assertThat(totalDuration.getRequestId()).as("total id").isEqualTo(requestId);
         softly.assertThat(totalDuration.getTopic()).as("total topic").isEqualTo("ObservedTotalDuration");
         softly.assertThat(totalDuration.getCorrelationId()).as("total correlationId").isEqualTo(CORRELATION_ID);
+        softly.assertThat(totalDuration.getSuccessResult()).as("getSuccessResult").isNotNull().isInstanceOf(Project.class);
+        softly.assertThat(totalDuration.getErrorResult()).as("getErrorResult").isNull();
         final ObservedSerializationDuration serializationDuration = metricObserver.get(ObservedSerializationDuration.class);
         softly.assertThat(serializationDuration.getRequest()).as("ser request").isEqualTo(sphereRequest);
         softly.assertThat(serializationDuration.getDurationInMilliseconds()).as("ser duration").isBetween(0L, 4L);


### PR DESCRIPTION
@lauraluiz  please review

release notes:

```html
 <li class=new-in-release>{@link ObservedTotalDuration#getErrorResult()},
 {@link ObservedTotalDuration#getSuccessResult()},
 {@link ObservedDeserializationDuration#getHttpResponse()}
 and {@link ObservedDeserializationDuration#getResult()} 
 for better analysis of metrics with the
 {@link io.sphere.sdk.client.metrics.SimpleMetricsSphereClient}</li>
```