### PR TITLE
fix bug wrong conversion Duration to TimeUnit

### DIFF
--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/BlockingSphereClient.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/BlockingSphereClient.java
@@ -84,6 +84,6 @@ public interface BlockingSphereClient extends SphereClient {
      * @return wrapped client which can perform blocking calls.
      */
     static BlockingSphereClient of(final SphereClient delegate, final Duration defaultTimeout) {
-        return of(delegate, defaultTimeout.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
+        return of(delegate, defaultTimeout.toMillis(), TimeUnit.MILLISECONDS);
     }
 }

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/BlockingSphereClientImpl.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/BlockingSphereClientImpl.java
@@ -43,6 +43,6 @@ final class BlockingSphereClientImpl extends Base implements BlockingSphereClien
 
     @Override
     public <T> T executeBlocking(final SphereRequest<T> sphereRequest, final Duration duration) {
-        return executeBlocking(sphereRequest, duration.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
+        return executeBlocking(sphereRequest, duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 }

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TimeoutSphereClientDecorator.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TimeoutSphereClientDecorator.java
@@ -28,7 +28,7 @@ public final class TimeoutSphereClientDecorator extends SphereClientDecorator im
     }
 
     public static SphereClient of(final SphereClient delegate, final Duration duration) {
-        return of(delegate, duration.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
+        return of(delegate, duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientUtils.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientUtils.java
@@ -26,7 +26,7 @@ public final class SphereClientUtils {
      * @throws SphereTimeoutException if a timeout occurs
      */
     public static <T> T blockingWait(final CompletionStage<T> completionStage, final Duration duration) {
-        return blockingWait(completionStage, duration.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
+        return blockingWait(completionStage, duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -55,7 +55,7 @@ public final class SphereClientUtils {
     }
 
     public static <T> List<T> blockingWaitForEach(final Stream<? extends CompletionStage<T>> stream, final Duration duration) {
-        return blockingWaitForEach(stream, duration.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
+        return blockingWaitForEach(stream, duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     public static <T> List<T> blockingWaitForEach(final Stream<? extends CompletionStage<T>> stream, final long timeout, final TimeUnit unit) {
@@ -65,7 +65,7 @@ public final class SphereClientUtils {
     }
 
     public static <T> List<T> blockingWaitForEach(final List<? extends CompletionStage<T>> list, final Duration duration) {
-        return blockingWaitForEach(list, duration.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
+        return blockingWaitForEach(list, duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     public static <T> List<T> blockingWaitForEach(final List<? extends CompletionStage<T>> list, final long timeout, final TimeUnit unit) {
@@ -78,6 +78,6 @@ public final class SphereClientUtils {
     }
 
     public static <S extends CompletionStage<T>, T> Collector<S, ?, List<T>> blockingWaitForEachCollector(final Duration duration) {
-        return blockingWaitForEachCollector(duration.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
+        return blockingWaitForEachCollector(duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
@lauraluiz please review

release notes:

```html
 <li class=fixed-in-release>conversion from {@link Duration} into {@link TimeUnit} for
 {@link io.sphere.sdk.client.BlockingSphereClient#executeBlocking(SphereRequest, Duration)},
 {@link io.sphere.sdk.client.TimeoutSphereClientDecorator#of(SphereClient, Duration)} 
 and the methods of {@link io.sphere.sdk.client.SphereClientUtils} (was causing silly timeouts)
 </li>
```