### PR TITLE
exists & missing filter, close #1027, close #1052, close #1058

### DIFF
--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/ExceptionFactory.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/ExceptionFactory.java
@@ -62,7 +62,7 @@ final class ExceptionFactory {
         return exceptionFactory;
     }
 
-    //hack since backend returns in same error conditions responce code 500 but with the message Service unavailable
+    //hack since backend returns in same error conditions response code 500 but with the message Service unavailable
     private static boolean isServiceNotAvailable(final HttpResponse httpResponse) {
         return httpResponse.getStatusCode() == 503 || Optional.ofNullable(httpResponse.getResponseBody()).map(b -> bytesToString(b)).map(s -> s.contains("<h2>Service Unavailable</h2>")).orElse(false);
     }

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TestDoubleSphereClientFactory.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TestDoubleSphereClientFactory.java
@@ -37,7 +37,7 @@ public final class TestDoubleSphereClientFactory extends Base {
                 final HttpRequestIntent httpRequest = sphereRequest.httpRequestIntent();
                 final HttpResponse httpResponse = function.apply(httpRequest);
                 try {
-                    final T t = SphereClientImpl.parse(sphereRequest, objectMapper, SphereApiConfig.of("fake-project-key-for-testing", "https://createHttpTestDouble.tld"), httpResponse);
+                    final T t = SphereClientImpl.parse(sphereRequest, objectMapper, SphereApiConfig.of("fake-project-key-for-testing", "https://createHttpTestDouble.tld"), httpResponse, null);
                     return CompletableFutureUtils.successful(t);
                 } catch (final Exception e) {
                     return CompletableFutureUtils.failed(e);

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/Product.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/Product.java
@@ -44,6 +44,7 @@ public interface Product extends ProductLike<Product, Product>, Resource<Product
      * @see io.sphere.sdk.products.commands.updateactions.TransitionState
      */
     @Nullable
+    @Override
     Reference<State> getState();
 
     /**

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
@@ -62,4 +62,16 @@ public final class ProductDraftBuilder extends ProductDataProductDraftBuilderBas
         this.masterVariant = masterVariant;
         return getThis();
     }
+
+    public ProductVariantDraft getMasterVariant() {
+        return masterVariant;
+    }
+
+    public ResourceIdentifier<ProductType> getProductType() {
+        return productType;
+    }
+
+    public List<ProductVariantDraft> getVariants() {
+        return variants;
+    }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductLike.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductLike.java
@@ -4,6 +4,7 @@ import io.sphere.sdk.models.ResourceView;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.reviews.ReviewRatingStatistics;
+import io.sphere.sdk.states.State;
 import io.sphere.sdk.taxcategories.TaxCategory;
 
 import javax.annotation.Nullable;
@@ -16,5 +17,8 @@ interface ProductLike<T, O> extends ResourceView<T, O>, ProductIdentifiable {
 
     @Nullable
     ReviewRatingStatistics getReviewRatingStatistics();
+
+    @Nullable
+    Reference<State> getState();
 
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductProjection.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductProjection.java
@@ -9,6 +9,7 @@ import io.sphere.sdk.models.Referenceable;
 import io.sphere.sdk.products.queries.ProductProjectionByIdGet;
 import io.sphere.sdk.reviews.ReviewRatingStatistics;
 import io.sphere.sdk.search.SearchKeywords;
+import io.sphere.sdk.states.State;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -170,4 +171,8 @@ public interface ProductProjection extends ProductLike<ProductProjection, Produc
     @Nullable
     @Override
     ReviewRatingStatistics getReviewRatingStatistics();
+
+    @Nullable
+    @Override
+    Reference<State> getState();
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductProjectionImpl.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductProjectionImpl.java
@@ -10,6 +10,7 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.reviews.ReviewRatingStatistics;
 import io.sphere.sdk.search.SearchKeywords;
+import io.sphere.sdk.states.State;
 import io.sphere.sdk.taxcategories.TaxCategory;
 
 import javax.annotation.Nullable;
@@ -20,6 +21,8 @@ import java.util.Set;
 
 class ProductProjectionImpl extends ResourceViewImpl<ProductProjection, Product> implements ProductProjection {
     private final Reference<ProductType> productType;
+    @Nullable
+    private final Reference<State> state;
     @Nullable
     private final Reference<TaxCategory> taxCategory;
     @JsonProperty("published")
@@ -48,7 +51,7 @@ class ProductProjectionImpl extends ResourceViewImpl<ProductProjection, Product>
 
     @JsonCreator
     ProductProjectionImpl(final String id, final Long version, final ZonedDateTime createdAt, final ZonedDateTime lastModifiedAt,
-                          final Reference<ProductType> productType, @Nullable final Reference<TaxCategory> taxCategory,
+                          final Reference<ProductType> productType, @Nullable final Reference<State> state, @Nullable final Reference<TaxCategory> taxCategory,
                           final Boolean hasStagedChanges, final LocalizedString name,
                           final Set<Reference<Category>> categories, @Nullable final LocalizedString description,
                           final LocalizedString slug, @Nullable final LocalizedString metaTitle,
@@ -59,6 +62,7 @@ class ProductProjectionImpl extends ResourceViewImpl<ProductProjection, Product>
                           @Nullable final ReviewRatingStatistics reviewRatingStatistics) {
         super(id, version, createdAt, lastModifiedAt);
         this.productType = productType;
+        this.state = state;
         this.taxCategory = taxCategory;
         this.hasStagedChanges = hasStagedChanges;
         this.name = name;
@@ -163,5 +167,11 @@ class ProductProjectionImpl extends ResourceViewImpl<ProductProjection, Product>
     @Nullable
     public ReviewRatingStatistics getReviewRatingStatistics() {
         return reviewRatingStatistics;
+    }
+
+    @Override
+    @Nullable
+    public Reference<State> getState() {
+        return state;
     }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductToProductProjectionWrapper.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductToProductProjectionWrapper.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.reviews.ReviewRatingStatistics;
 import io.sphere.sdk.search.SearchKeywords;
+import io.sphere.sdk.states.State;
 import io.sphere.sdk.taxcategories.TaxCategory;
 
 import javax.annotation.Nullable;
@@ -127,5 +128,11 @@ class ProductToProductProjectionWrapper implements ProductProjection {
     @Override
     public ReviewRatingStatistics getReviewRatingStatistics() {
         return product.getReviewRatingStatistics();
+    }
+
+    @Nullable
+    @Override
+    public Reference<State> getState() {
+        return product.getState();
     }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductDataFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductDataFilterSearchModel.java
@@ -45,7 +45,11 @@ public abstract class ProductDataFilterSearchModel extends SearchModelImpl<Produ
         return new ReviewRatingStatisticsFilterSearchModel<>(this, "reviewRatingStatistics");
     }
 
-    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> taxCategory() {
-        return existsAndMissingFilterSearchModelSupport("taxCategory");
+    public ReferenceFilterSearchModel<ProductProjection> taxCategory() {
+        return referenceFilterSearchModel("taxCategory");
+    }
+
+    public ReferenceFilterSearchModel<ProductProjection> state() {
+        return referenceFilterSearchModel("state");
     }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductDataFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductDataFilterSearchModel.java
@@ -44,4 +44,8 @@ public abstract class ProductDataFilterSearchModel extends SearchModelImpl<Produ
     public ReviewRatingStatisticsFilterSearchModel<ProductProjection> reviewRatingStatistics() {
         return new ReviewRatingStatisticsFilterSearchModel<>(this, "reviewRatingStatistics");
     }
+
+    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> taxCategory() {
+        return existsAndMissingFilterSearchModelSupport("taxCategory");
+    }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
@@ -58,11 +58,12 @@ public final class ProductProjectionFilterSearchModel extends ProductDataFilterS
     }
 
     @Override
-    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> taxCategory() {
+    public ReferenceFilterSearchModel<ProductProjection> taxCategory() {
         return super.taxCategory();
     }
 
-    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> state() {
-        return existsAndMissingFilterSearchModelSupport("state");
+    @Override
+    public ReferenceFilterSearchModel<ProductProjection> state() {
+        return super.state();
     }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
@@ -61,4 +61,8 @@ public final class ProductProjectionFilterSearchModel extends ProductDataFilterS
     public ExistsAndMissingFilterSearchModelSupport<ProductProjection> taxCategory() {
         return super.taxCategory();
     }
+
+    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> state() {
+        return existsAndMissingFilterSearchModelSupport("state");
+    }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
@@ -56,4 +56,9 @@ public final class ProductProjectionFilterSearchModel extends ProductDataFilterS
     public ReviewRatingStatisticsFilterSearchModel<ProductProjection> reviewRatingStatistics() {
         return super.reviewRatingStatistics();
     }
+
+    @Override
+    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> taxCategory() {
+        return super.taxCategory();
+    }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductVariantFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductVariantFilterSearchModel.java
@@ -1,10 +1,7 @@
 package io.sphere.sdk.products.search;
 
 import io.sphere.sdk.products.ProductProjection;
-import io.sphere.sdk.search.model.ExistsAndMissingFilterSearchModelSupport;
-import io.sphere.sdk.search.model.MoneyFilterSearchModel;
-import io.sphere.sdk.search.model.SearchModel;
-import io.sphere.sdk.search.model.SearchModelImpl;
+import io.sphere.sdk.search.model.*;
 
 import javax.annotation.Nullable;
 
@@ -22,8 +19,12 @@ public final class ProductVariantFilterSearchModel extends SearchModelImpl<Produ
         return moneyFilterSearchModel("price");
     }
 
-    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> sku() {
-        return existsAndMissingFilterSearchModelSupport("sku");
+    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> prices() {
+        return existsAndMissingFilterSearchModelSupport("prices");
+    }
+
+    public TermFilterSearchModel<ProductProjection, String> sku() {
+        return stringSearchModel("sku").filtered();
     }
 
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductVariantFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductVariantFilterSearchModel.java
@@ -1,6 +1,7 @@
 package io.sphere.sdk.products.search;
 
 import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.search.model.ExistsAndMissingFilterSearchModelSupport;
 import io.sphere.sdk.search.model.MoneyFilterSearchModel;
 import io.sphere.sdk.search.model.SearchModel;
 import io.sphere.sdk.search.model.SearchModelImpl;
@@ -20,4 +21,9 @@ public final class ProductVariantFilterSearchModel extends SearchModelImpl<Produ
     public MoneyFilterSearchModel<ProductProjection> price() {
         return moneyFilterSearchModel("price");
     }
+
+    public ExistsAndMissingFilterSearchModelSupport<ProductProjection> sku() {
+        return existsAndMissingFilterSearchModelSupport("sku");
+    }
+
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductFixtures.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductFixtures.java
@@ -100,7 +100,7 @@ public class ProductFixtures {
     }
 
     public static void withProduct(final BlockingSphereClient client, final UnaryOperator<ProductDraftBuilder> builderMapper, final Consumer<Product> productConsumer) {
-        withEmptyProductType(client, productType -> {
+        withAttributesProductType(client, productType -> {
             final ProductDraftBuilder builder = ProductDraftBuilder.of(productType, randomSlug(), randomSlug(), ProductVariantDraftBuilder.of().build());
             final ProductDraftBuilder updatedBuilder = builderMapper.apply(builder);
             final Product product = client.executeBlocking(ProductCreateCommand.of(updatedBuilder.build()));

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
@@ -3,6 +3,7 @@ package io.sphere.sdk.products.search;
 import io.sphere.sdk.products.*;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
+import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
@@ -77,7 +78,26 @@ public class ExistFilterIntegrationTest extends IntegrationTest {
         }, m -> m.allVariants().sku());
     }
 
-    //TODO for prices, not clear when it is price and prices
+    @Test
+    public void prices() {
+        checkFilter(builder -> {
+            final ProductVariantDraft oldMaster = builder.getMasterVariant();
+            final ProductVariantDraft masterWithPrices = ProductVariantDraftBuilder.of(oldMaster)
+                    .prices(singletonList(PriceDraft.of(EURO_1)))
+                    .build();
+            return builder.masterVariant(masterWithPrices);
+        }, m -> m.allVariants().prices());
+    }
+
+    @Test
+    public void productAttribute() {
+        checkFilter(builder -> {
+            final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of(builder.getMasterVariant())
+                    .attributes(AttributeDraft.of("stringfield", "hello"))
+                    .build();
+            return builder.masterVariant(masterVariant);
+        }, m -> m.allVariants().attribute().ofString("stringfield"));
+    }
 
     private void checkFilter(final UnaryOperator<ProductDraftBuilder> productDraftBuilderUnaryOperator, final Function<ProductProjectionFilterSearchModel, ExistsAndMissingFilterSearchModelSupport<ProductProjection>> dsl) {
         withProduct(client(), productDraftBuilderUnaryOperator, productWith -> {
@@ -96,6 +116,4 @@ public class ExistFilterIntegrationTest extends IntegrationTest {
             });
         });
     }
-
-    //custom attribute
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
@@ -1,8 +1,6 @@
 package io.sphere.sdk.products.search;
 
-import io.sphere.sdk.products.ProductDraftBuilder;
-import io.sphere.sdk.products.ProductFixtures;
-import io.sphere.sdk.products.ProductProjection;
+import io.sphere.sdk.products.*;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
 import io.sphere.sdk.products.attributes.StringAttributeType;
@@ -21,6 +19,7 @@ import java.util.function.UnaryOperator;
 
 import static io.sphere.sdk.categories.CategoryFixtures.withCategory;
 import static io.sphere.sdk.products.ProductFixtures.withProduct;
+import static io.sphere.sdk.taxcategories.TaxCategoryFixtures.withTaxCategory;
 import static io.sphere.sdk.test.SphereTestUtils.*;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -51,8 +50,26 @@ public class ExistFilterIntegrationTest extends IntegrationTest {
         withCategory(client(), category -> {
             checkFilter(builder -> builder.categories(singleton(category.toReference())), m -> m.categories());
         });
-
     }
+
+    @Test
+    public void taxCategory() {
+        withTaxCategory(client(), taxCategory -> {
+            checkFilter(builder -> builder.taxCategory(taxCategory), m -> m.taxCategory());
+        });
+    }
+
+    @Test
+    public void sku() {
+        checkFilter(builder -> {
+            final ProductVariantDraft masterVariant = ProductVariantDraftBuilder.of(builder.getMasterVariant())
+                    .sku("sku-of-master")
+                    .build();
+            return builder.masterVariant(masterVariant);
+        }, m -> m.allVariants().sku());
+    }
+
+    //TODO for prices, not clear when it is price and prices
 
     private void checkFilter(final UnaryOperator<ProductDraftBuilder> productDraftBuilderUnaryOperator, final Function<ProductProjectionFilterSearchModel, ExistsAndMissingFilterSearchModelSupport<ProductProjection>> dsl) {
         withProduct(client(), productDraftBuilderUnaryOperator, productWith -> {
@@ -72,10 +89,6 @@ public class ExistFilterIntegrationTest extends IntegrationTest {
         });
     }
 
-    //categories
-    //prices
-    //sku
-    //taxcategory
     //state
     //custom attribute
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
@@ -19,6 +19,7 @@ import java.util.function.UnaryOperator;
 
 import static io.sphere.sdk.categories.CategoryFixtures.withCategory;
 import static io.sphere.sdk.products.ProductFixtures.withProduct;
+import static io.sphere.sdk.states.StateFixtures.withState;
 import static io.sphere.sdk.taxcategories.TaxCategoryFixtures.withTaxCategory;
 import static io.sphere.sdk.test.SphereTestUtils.*;
 import static java.util.Collections.singleton;
@@ -49,6 +50,13 @@ public class ExistFilterIntegrationTest extends IntegrationTest {
     public void categories() {
         withCategory(client(), category -> {
             checkFilter(builder -> builder.categories(singleton(category.toReference())), m -> m.categories());
+        });
+    }
+
+    @Test
+    public void state() {
+        withState(client(), draft -> draft, state -> {
+            checkFilter(builder -> builder.state(state), m -> m.state());
         });
     }
 
@@ -89,6 +97,5 @@ public class ExistFilterIntegrationTest extends IntegrationTest {
         });
     }
 
-    //state
     //custom attribute
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
@@ -1,0 +1,74 @@
+package io.sphere.sdk.products.search;
+
+import io.sphere.sdk.products.ProductFixtures;
+import io.sphere.sdk.products.attributes.AttributeDefinition;
+import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
+import io.sphere.sdk.products.attributes.StringAttributeType;
+import io.sphere.sdk.producttypes.ProductType;
+import io.sphere.sdk.producttypes.ProductTypeDraft;
+import io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand;
+import io.sphere.sdk.test.IntegrationTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.sphere.sdk.categories.CategoryFixtures.withCategory;
+import static io.sphere.sdk.products.ProductFixtures.withProduct;
+import static io.sphere.sdk.test.SphereTestUtils.*;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExistFilterIntegrationTest extends IntegrationTest {
+    public static final String PRODUCT_TYPE_KEY = ExistFilterIntegrationTest.class.getSimpleName();
+    private static ProductType productType;
+
+    @AfterClass
+    public static void delete() {
+        ProductFixtures.deleteProductsAndProductTypes(client());
+        productType = null;
+    }
+
+    @BeforeClass
+    public static void createData() {
+        ProductFixtures.deleteProductsAndProductTypes(client());
+        final String stringattribute = "stringattribute";
+        final List<AttributeDefinition> attributes = singletonList(AttributeDefinitionBuilder.of(stringattribute, randomSlug(), StringAttributeType.of()).build());
+        final ProductTypeDraft productTypeDraft =
+                ProductTypeDraft.of(PRODUCT_TYPE_KEY, PRODUCT_TYPE_KEY, PRODUCT_TYPE_KEY, attributes);
+        productType = client().executeBlocking(ProductTypeCreateCommand.of(productTypeDraft));
+    }
+
+    @Test
+    public void categories() {
+        withCategory(client(), category -> {
+            withProduct(client(), builder -> builder.categories(singleton(category.toReference())), productWith -> {
+                withProduct(client(), productWithout -> {
+                    final ProductProjectionSearch baseRequest = ProductProjectionSearch.ofStaged()
+                            .withQueryFilters(m -> {
+                                final List<String> productIds = asList(productWith.getId(), productWithout.getId());
+                                return m.id().isIn(productIds);
+                            });
+
+                    final ProductProjectionSearch exists = baseRequest.plusQueryFilters(m -> m.categories().exists());
+                    final ProductProjectionSearch missing = baseRequest.plusQueryFilters(m -> m.categories().missing());
+
+                   assertEventually(() -> {
+                       assertThat(client().executeBlocking(exists).getResults()).hasSize(1).extracting(s -> s.getId()).containsExactly(productWith.getId());
+                       assertThat(client().executeBlocking(missing).getResults()).hasSize(1).extracting(s -> s.getId()).containsExactly(productWithout.getId());
+                   });
+                });
+            });
+        });
+
+    }
+
+    //categories
+    //prices
+    //sku
+    //taxcategory
+    //state
+    //custom attribute
+}

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistFilterIntegrationTest.java
@@ -1,18 +1,23 @@
 package io.sphere.sdk.products.search;
 
+import io.sphere.sdk.products.ProductDraftBuilder;
 import io.sphere.sdk.products.ProductFixtures;
+import io.sphere.sdk.products.ProductProjection;
 import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
 import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.producttypes.ProductTypeDraft;
 import io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand;
+import io.sphere.sdk.search.model.ExistsAndMissingFilterSearchModelSupport;
 import io.sphere.sdk.test.IntegrationTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static io.sphere.sdk.categories.CategoryFixtures.withCategory;
 import static io.sphere.sdk.products.ProductFixtures.withProduct;
@@ -44,25 +49,27 @@ public class ExistFilterIntegrationTest extends IntegrationTest {
     @Test
     public void categories() {
         withCategory(client(), category -> {
-            withProduct(client(), builder -> builder.categories(singleton(category.toReference())), productWith -> {
-                withProduct(client(), productWithout -> {
-                    final ProductProjectionSearch baseRequest = ProductProjectionSearch.ofStaged()
-                            .withQueryFilters(m -> {
-                                final List<String> productIds = asList(productWith.getId(), productWithout.getId());
-                                return m.id().isIn(productIds);
-                            });
-
-                    final ProductProjectionSearch exists = baseRequest.plusQueryFilters(m -> m.categories().exists());
-                    final ProductProjectionSearch missing = baseRequest.plusQueryFilters(m -> m.categories().missing());
-
-                   assertEventually(() -> {
-                       assertThat(client().executeBlocking(exists).getResults()).hasSize(1).extracting(s -> s.getId()).containsExactly(productWith.getId());
-                       assertThat(client().executeBlocking(missing).getResults()).hasSize(1).extracting(s -> s.getId()).containsExactly(productWithout.getId());
-                   });
-                });
-            });
+            checkFilter(builder -> builder.categories(singleton(category.toReference())), m -> m.categories());
         });
 
+    }
+
+    private void checkFilter(final UnaryOperator<ProductDraftBuilder> productDraftBuilderUnaryOperator, final Function<ProductProjectionFilterSearchModel, ExistsAndMissingFilterSearchModelSupport<ProductProjection>> dsl) {
+        withProduct(client(), productDraftBuilderUnaryOperator, productWith -> {
+            withProduct(client(), productWithout -> {
+                final ProductProjectionSearch baseRequest = ProductProjectionSearch.ofStaged()
+                        .withQueryFilters(m -> {
+                            final List<String> productIds = asList(productWith.getId(), productWithout.getId());
+                            return m.id().isIn(productIds);
+                        });
+                final ProductProjectionSearch exists = baseRequest.plusQueryFilters(m -> dsl.apply(m).exists());
+                final ProductProjectionSearch missing = baseRequest.plusQueryFilters(m -> dsl.apply(m).missing());
+               assertEventually(() -> {
+                   assertThat(client().executeBlocking(exists).getResults()).hasSize(1).extracting(s -> s.getId()).containsExactly(productWith.getId());
+                   assertThat(client().executeBlocking(missing).getResults()).hasSize(1).extracting(s -> s.getId()).containsExactly(productWithout.getId());
+               });
+            });
+        });
     }
 
     //categories

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistsAndMissingFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistsAndMissingFilterIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.sphere.sdk.products.search;
 
+import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.*;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.search.model.ExistsAndMissingFilterSearchModelSupport;
@@ -7,6 +8,7 @@ import io.sphere.sdk.test.IntegrationTest;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -102,6 +104,12 @@ public class ExistsAndMissingFilterIntegrationTest extends IntegrationTest {
                     .build();
             return builder.masterVariant(masterVariant);
         }, m -> m.allVariants().sku());
+    }
+
+    @Test
+    public void nameLocale() {
+        checkFilter(builder -> builder.name(LocalizedString.of(Locale.GERMAN, "foo")),
+                m -> m.name().locale(Locale.GERMAN));
     }
 
     @Test

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ProductProjectionSearchTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ProductProjectionSearchTest.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import static io.sphere.sdk.test.SphereTestUtils.DE;
 import static io.sphere.sdk.test.SphereTestUtils.EUR;
@@ -231,6 +232,12 @@ public class ProductProjectionSearchTest {
         final ProductProjectionSearch priceSelectionRemoved = SEARCH_WITH_FULL_PRICE_SELECTION.withPriceSelection(null);
         assertThat(priceSelectionRemoved.httpRequestIntent().getBody().toString()).doesNotContain("price");
         assertThat(priceSelectionRemoved.getPriceSelection()).isNull();
+    }
+
+    @Test
+    public void existFilter() {
+        final List<FilterExpression<ProductProjection>> exists = FILTER_MODEL.categories().exists();
+        assertThat(exists).extracting(expression()).containsExactly("categories:exists");
     }
 
     //    @Test

--- a/commercetools-models/src/test/java/io/sphere/sdk/producttypes/ProductTypeFixtures.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/producttypes/ProductTypeFixtures.java
@@ -5,6 +5,7 @@ import io.sphere.sdk.products.attributes.AttributeDefinition;
 import io.sphere.sdk.products.attributes.AttributeDefinitionBuilder;
 import io.sphere.sdk.products.attributes.ReferenceAttributeType;
 import io.sphere.sdk.products.Product;
+import io.sphere.sdk.products.attributes.StringAttributeType;
 import io.sphere.sdk.products.queries.ProductQuery;
 import io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand;
 import io.sphere.sdk.producttypes.commands.ProductTypeDeleteCommand;
@@ -32,6 +33,15 @@ public final class ProductTypeFixtures {
 
     public static void withEmptyProductType(final BlockingSphereClient client, final Consumer<ProductType> user) {
         withProductType(client, () -> newEmptyProductDraft(), user);
+    }
+
+    public static void withAttributesProductType(final BlockingSphereClient client, final Consumer<ProductType> user) {
+        withProductType(client, () -> {
+            final AttributeDefinition stringAttribute = AttributeDefinitionBuilder
+                    .of("stringfield", randomSlug(), StringAttributeType.of())
+                    .build();
+            return ProductTypeDraft.of(randomKey(), randomKey(), "desc", Collections.singletonList(stringAttribute));
+        }, user);
     }
 
     public static ProductTypeDraft newEmptyProductDraft() {

--- a/commercetools-models/src/test/java/io/sphere/sdk/states/StateFixtures.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/states/StateFixtures.java
@@ -21,6 +21,7 @@ import static io.sphere.sdk.test.SphereTestUtils.randomKey;
 import static io.sphere.sdk.utils.SphereInternalUtils.asSet;
 import static io.sphere.sdk.utils.SphereInternalUtils.setOf;
 import static java.util.Locale.ENGLISH;
+import static java.util.Locale.PRC;
 
 public class StateFixtures {
     private StateFixtures() {
@@ -46,6 +47,13 @@ public class StateFixtures {
         final StateDraftBuilder stateDraftBuilder = StateDraftBuilder.of(createStateDraft(randomKey()));
         final StateDraft stateDraft = drafting.apply(stateDraftBuilder).build();
         withState(client, stateDraft, consumer);
+    }
+
+    public static void withState(final BlockingSphereClient client, final UnaryOperator<StateDraftBuilder> builderUnaryOperator, final Consumer<State> consumer) {
+        withUpdateableState(client, builderUnaryOperator, state -> {
+            consumer.accept(state);
+            return state;
+        });
     }
 
     public static void withState(final BlockingSphereClient client, final StateDraft stateDraft, final Consumer<State> consumer) {

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/EnumFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/EnumFilterSearchModel.java
@@ -1,8 +1,11 @@
 package io.sphere.sdk.search.model;
 
-import javax.annotation.Nullable;
+import io.sphere.sdk.search.FilterExpression;
 
-public final class EnumFilterSearchModel<T> extends SearchModelImpl<T> {
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class EnumFilterSearchModel<T> extends SearchModelImpl<T> implements ExistsAndMissingFilterSearchModelSupport<T> {
 
     EnumFilterSearchModel(@Nullable final SearchModel<T> parent, @Nullable final String pathSegment) {
         super(parent, pathSegment);
@@ -14,5 +17,15 @@ public final class EnumFilterSearchModel<T> extends SearchModelImpl<T> {
 
     public TermFilterSearchModel<T, String> label() {
         return new StringSearchModel<>(this, "label").filtered();
+    }
+
+    @Override
+    public List<FilterExpression<T>> exists() {
+        return existsFilters();
+    }
+
+    @Override
+    public List<FilterExpression<T>> missing() {
+        return missingFilters();
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupport.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupport.java
@@ -1,0 +1,13 @@
+package io.sphere.sdk.search.model;
+
+import io.sphere.sdk.search.FilterExpression;
+
+import java.util.List;
+
+public interface ExistsAndMissingFilterSearchModelSupport<T> extends MissingFilterSearchModelSupport<T>, ExistsFilterSearchModelSupport<T> {
+    @Override
+    List<FilterExpression<T>> exists();
+
+    @Override
+    List<FilterExpression<T>> missing();
+}

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupportImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupportImpl.java
@@ -1,0 +1,22 @@
+package io.sphere.sdk.search.model;
+
+import io.sphere.sdk.search.FilterExpression;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+final class ExistsAndMissingFilterSearchModelSupportImpl<T> extends SearchModelImpl<T> implements ExistsAndMissingFilterSearchModelSupport<T> {
+    ExistsAndMissingFilterSearchModelSupportImpl(@Nullable final SearchModel<T> parent, @Nullable final String pathSegment) {
+        super(parent, pathSegment);
+    }
+
+    @Override
+    public List<FilterExpression<T>> exists() {
+        return existsFilters();
+    }
+
+    @Override
+    public List<FilterExpression<T>> missing() {
+        return missingFilters();
+    }
+}

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupportUtils.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupportUtils.java
@@ -2,8 +2,11 @@ package io.sphere.sdk.search.model;
 
 import io.sphere.sdk.search.FilterExpression;
 
+import java.util.Collections;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 final class ExistsAndMissingFilterSearchModelSupportUtils {
@@ -19,6 +22,7 @@ final class ExistsAndMissingFilterSearchModelSupportUtils {
     }
 
     private static <T> List<FilterExpression<T>> verbFilter(final SearchModel<T> model, final String verb) {
-        return model.buildPath().stream().map(path -> FilterExpression.<T>of(path + (":" + verb))).collect(toList());
+        final String path = model.buildPath().stream().collect(joining("."));
+        return singletonList(FilterExpression.of(path + ":" + verb));
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupportUtils.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsAndMissingFilterSearchModelSupportUtils.java
@@ -1,0 +1,24 @@
+package io.sphere.sdk.search.model;
+
+import io.sphere.sdk.search.FilterExpression;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+final class ExistsAndMissingFilterSearchModelSupportUtils {
+    public ExistsAndMissingFilterSearchModelSupportUtils() {
+    }
+
+    static <T> List<FilterExpression<T>> exists(final SearchModel<T> model) {
+        return verbFilter(model, "exists");
+    }
+
+    static <T> List<FilterExpression<T>> missing(final SearchModel<T> model) {
+        return verbFilter(model, "missing");
+    }
+
+    private static <T> List<FilterExpression<T>> verbFilter(final SearchModel<T> model, final String verb) {
+        return model.buildPath().stream().map(path -> FilterExpression.<T>of(path + (":" + verb))).collect(toList());
+    }
+}

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsFilterSearchModelSupport.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsFilterSearchModelSupport.java
@@ -5,5 +5,12 @@ import io.sphere.sdk.search.FilterExpression;
 import java.util.List;
 
 public interface ExistsFilterSearchModelSupport<T> {
+    /**
+     * Creates filters for a field that contains at least one value.
+     *
+     * {@include.example io.sphere.sdk.products.search.ExistsAndMissingFilterIntegrationTest#categoriesExists()}
+     *
+     * @return filters
+     */
     List<FilterExpression<T>> exists();
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsFilterSearchModelSupport.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ExistsFilterSearchModelSupport.java
@@ -1,0 +1,9 @@
+package io.sphere.sdk.search.model;
+
+import io.sphere.sdk.search.FilterExpression;
+
+import java.util.List;
+
+public interface ExistsFilterSearchModelSupport<T> {
+    List<FilterExpression<T>> exists();
+}

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/LocalizedEnumFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/LocalizedEnumFilterSearchModel.java
@@ -1,8 +1,11 @@
 package io.sphere.sdk.search.model;
 
-import javax.annotation.Nullable;
+import io.sphere.sdk.search.FilterExpression;
 
-public final class LocalizedEnumFilterSearchModel<T> extends SearchModelImpl<T> {
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class LocalizedEnumFilterSearchModel<T> extends SearchModelImpl<T> implements ExistsAndMissingFilterSearchModelSupport<T> {
 
     LocalizedEnumFilterSearchModel(@Nullable final SearchModel<T> parent, @Nullable final String pathSegment) {
         super(parent, pathSegment);
@@ -14,5 +17,15 @@ public final class LocalizedEnumFilterSearchModel<T> extends SearchModelImpl<T> 
 
     public LocalizedStringFilterSearchModel<T> label() {
         return new LocalizedStringFilterSearchModel<>(this, "label");
+    }
+
+    @Override
+    public List<FilterExpression<T>> exists() {
+        return existsFilters();
+    }
+
+    @Override
+    public List<FilterExpression<T>> missing() {
+        return missingFilters();
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/LocalizedStringFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/LocalizedStringFilterSearchModel.java
@@ -1,9 +1,12 @@
 package io.sphere.sdk.search.model;
 
+import io.sphere.sdk.search.FilterExpression;
+
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Locale;
 
-public final class LocalizedStringFilterSearchModel<T> extends SearchModelImpl<T> {
+public final class LocalizedStringFilterSearchModel<T> extends SearchModelImpl<T> implements ExistsAndMissingFilterSearchModelSupport<T> {
 
     LocalizedStringFilterSearchModel(@Nullable final SearchModel<T> parent, @Nullable final String pathSegment) {
         super(parent, pathSegment);
@@ -11,5 +14,15 @@ public final class LocalizedStringFilterSearchModel<T> extends SearchModelImpl<T
 
     public TermFilterSearchModel<T, String> locale(final Locale locale) {
         return new StringSearchModel<>(this, locale.toLanguageTag()).filtered();
+    }
+
+    @Override
+    public List<FilterExpression<T>> exists() {
+        return existsFilters();
+    }
+
+    @Override
+    public List<FilterExpression<T>> missing() {
+        return missingFilters();
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MissingFilterSearchModelSupport.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MissingFilterSearchModelSupport.java
@@ -5,5 +5,12 @@ import io.sphere.sdk.search.FilterExpression;
 import java.util.List;
 
 public interface MissingFilterSearchModelSupport<T> {
+    /**
+     * Creates filters for fields that contain no values.
+     *
+     * {@include.example io.sphere.sdk.products.search.ExistsAndMissingFilterIntegrationTest#categoriesMissing()}
+     *
+     * @return filters
+     */
     List<FilterExpression<T>> missing();
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MissingFilterSearchModelSupport.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MissingFilterSearchModelSupport.java
@@ -1,0 +1,9 @@
+package io.sphere.sdk.search.model;
+
+import io.sphere.sdk.search.FilterExpression;
+
+import java.util.List;
+
+public interface MissingFilterSearchModelSupport<T> {
+    List<FilterExpression<T>> missing();
+}

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MoneyFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MoneyFilterSearchModel.java
@@ -1,9 +1,12 @@
 package io.sphere.sdk.search.model;
 
+import io.sphere.sdk.search.FilterExpression;
+
 import javax.annotation.Nullable;
 import javax.money.CurrencyUnit;
+import java.util.List;
 
-public final class MoneyFilterSearchModel<T> extends SearchModelImpl<T> {
+public final class MoneyFilterSearchModel<T> extends SearchModelImpl<T> implements ExistsAndMissingFilterSearchModelSupport<T> {
 
     MoneyFilterSearchModel(@Nullable final SearchModel<T> parent, @Nullable final String pathSegment) {
         super(parent, pathSegment);
@@ -15,5 +18,15 @@ public final class MoneyFilterSearchModel<T> extends SearchModelImpl<T> {
 
     public TermFilterSearchModel<T, CurrencyUnit> currency() {
         return new CurrencySearchModel<>(this, "currencyCode").filtered();
+    }
+
+    @Override
+    public List<FilterExpression<T>> exists() {
+        return existsFilters();
+    }
+
+    @Override
+    public List<FilterExpression<T>> missing() {
+        return missingFilters();
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ReferenceFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ReferenceFilterSearchModel.java
@@ -1,6 +1,9 @@
 package io.sphere.sdk.search.model;
 
+import io.sphere.sdk.search.FilterExpression;
+
 import javax.annotation.Nullable;
+import java.util.List;
 
 public final class ReferenceFilterSearchModel<T> extends SearchModelImpl<T> {
 
@@ -10,5 +13,13 @@ public final class ReferenceFilterSearchModel<T> extends SearchModelImpl<T> {
 
     public TermFilterSearchModel<T, String> id() {
         return new StringSearchModel<>(this, "id").filtered();
+    }
+
+    public List<FilterExpression<T>> exists() {
+        return existsFilters();
+    }
+
+    public List<FilterExpression<T>> missing() {
+        return missingFilters();
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ReferenceFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/ReferenceFilterSearchModel.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.search.FilterExpression;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public final class ReferenceFilterSearchModel<T> extends SearchModelImpl<T> {
+public final class ReferenceFilterSearchModel<T> extends SearchModelImpl<T> implements ExistsAndMissingFilterSearchModelSupport<T> {
 
     ReferenceFilterSearchModel(@Nullable final SearchModel<T> parent, @Nullable final String pathSegment) {
         super(parent, pathSegment);
@@ -15,10 +15,12 @@ public final class ReferenceFilterSearchModel<T> extends SearchModelImpl<T> {
         return new StringSearchModel<>(this, "id").filtered();
     }
 
+    @Override
     public List<FilterExpression<T>> exists() {
         return existsFilters();
     }
 
+    @Override
     public List<FilterExpression<T>> missing() {
         return missingFilters();
     }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
@@ -128,18 +128,6 @@ public class SearchModelImpl<T> extends Base implements SearchModel<T> {
         return new ReferenceFacetedSearchSearchModel<>(this, pathSegment);
     }
 
-    protected List<FilterExpression<T>> missingFilters() {
-        return verbFilter("missing");
-    }
-
-    protected List<FilterExpression<T>> existsFilters() {
-        return verbFilter("exists");
-    }
-
-    private List<FilterExpression<T>> verbFilter(final String verb) {
-        return buildPath().stream().map(path -> FilterExpression.<T>of(path + (":" + verb))).collect(toList());
-    }
-
     protected ExistsAndMissingFilterSearchModelSupport<T> existsAndMissingFilterSearchModelSupport(final String fieldName) {
         return new ExistsAndMissingFilterSearchModelSupportImpl<T>(this, fieldName);
     }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
@@ -4,7 +4,6 @@ import io.sphere.sdk.models.Base;
 import io.sphere.sdk.search.FilterExpression;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -139,5 +138,9 @@ public class SearchModelImpl<T> extends Base implements SearchModel<T> {
 
     private List<FilterExpression<T>> verbFilter(final String verb) {
         return buildPath().stream().map(path -> FilterExpression.<T>of(path + (":" + verb))).collect(toList());
+    }
+
+    protected ExistsAndMissingFilterSearchModelSupport<T> existsAndMissingFilterSearchModelSupport(final String fieldName) {
+        return new ExistsAndMissingFilterSearchModelSupportImpl<T>(this, fieldName);
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
@@ -131,4 +131,12 @@ public class SearchModelImpl<T> extends Base implements SearchModel<T> {
     protected ExistsAndMissingFilterSearchModelSupport<T> existsAndMissingFilterSearchModelSupport(final String fieldName) {
         return new ExistsAndMissingFilterSearchModelSupportImpl<T>(this, fieldName);
     }
+
+    protected List<FilterExpression<T>> existsFilters() {
+        return ExistsAndMissingFilterSearchModelSupportUtils.exists(this);
+    }
+
+    protected List<FilterExpression<T>> missingFilters() {
+        return ExistsAndMissingFilterSearchModelSupportUtils.missing(this);
+    }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SearchModelImpl.java
@@ -1,8 +1,13 @@
 package io.sphere.sdk.search.model;
 
 import io.sphere.sdk.models.Base;
+import io.sphere.sdk.search.FilterExpression;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 public class SearchModelImpl<T> extends Base implements SearchModel<T> {
     @Nullable
@@ -122,5 +127,17 @@ public class SearchModelImpl<T> extends Base implements SearchModel<T> {
 
     protected ReferenceFacetedSearchSearchModel<T> referenceFacetedSearchSearchModel(final String pathSegment) {
         return new ReferenceFacetedSearchSearchModel<>(this, pathSegment);
+    }
+
+    protected List<FilterExpression<T>> missingFilters() {
+        return verbFilter("missing");
+    }
+
+    protected List<FilterExpression<T>> existsFilters() {
+        return verbFilter("exists");
+    }
+
+    private List<FilterExpression<T>> verbFilter(final String verb) {
+        return buildPath().stream().map(path -> FilterExpression.<T>of(path + (":" + verb))).collect(toList());
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
@@ -32,7 +32,7 @@ abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSea
 
     @Override
     public List<FilterExpression<T>> missing() {
-        return ExistsAndMissingFilterSearchModelSupportUtils.exists(searchModel);
+        return ExistsAndMissingFilterSearchModelSupportUtils.missing(searchModel);
     }
 
     /**

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
@@ -16,13 +16,27 @@ import static java.util.stream.Collectors.toList;
  * @param <T> type of the resource
  * @param <V> type of the value
  */
-abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSearchModel<T, V> {
+abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSearchModel<T, V>, ExistsAndMissingFilterSearchModelSupport<T> {
     protected final SearchModel<T> searchModel;
     protected final Function<V, String> typeSerializer;
 
     TermFilterBaseSearchModel(final SearchModel<T> searchModel, final Function<V, String> typeSerializer) {
         this.searchModel = searchModel;
         this.typeSerializer = typeSerializer;
+    }
+
+    @Override
+    public List<FilterExpression<T>> exists() {
+        return verbFilter("exists");
+    }
+
+    @Override
+    public List<FilterExpression<T>> missing() {
+        return verbFilter("missing");
+    }
+
+    private List<FilterExpression<T>> verbFilter(final String verb) {
+        return searchModel.buildPath().stream().map(path -> FilterExpression.<T>of(path + (":" + verb))).collect(toList());
     }
 
     /**

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
@@ -27,16 +27,12 @@ abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSea
 
     @Override
     public List<FilterExpression<T>> exists() {
-        return verbFilter("exists");
+        return ExistsAndMissingFilterSearchModelSupportUtils.exists(searchModel);
     }
 
     @Override
     public List<FilterExpression<T>> missing() {
-        return verbFilter("missing");
-    }
-
-    private List<FilterExpression<T>> verbFilter(final String verb) {
-        return searchModel.buildPath().stream().map(path -> FilterExpression.<T>of(path + (":" + verb))).collect(toList());
+        return ExistsAndMissingFilterSearchModelSupportUtils.exists(searchModel);
     }
 
     /**


### PR DESCRIPTION
- add missing filter which excludes elements which have no value for a certain field
- add exists filter which only includes elements which have no value for a certain field
- improve error reporting, now the http request is also shown if a search request and others fail
- it also contains a filter for taxCategory and sku
- add state field to product projection